### PR TITLE
Make some members public to allow getting which members would be serialized

### DIFF
--- a/JECS/Parsing Logic/ClassMember.cs
+++ b/JECS/Parsing Logic/ClassMember.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace JECS.ParsingLogic
 {
-    internal sealed class ClassMember
+    public sealed class ClassMember
     {
         public string Name { get; }
         public Type MemberType { get; }

--- a/JECS/Parsing Logic/Types/Complex Types/ComplexTypes.cs
+++ b/JECS/Parsing Logic/Types/Complex Types/ComplexTypes.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace JECS.ParsingLogic
 {
-    internal static class ComplexTypes
+    public static class ComplexTypes
     {
         internal const string KEY_CONCRETE_TYPE = "{JECS_CONCRETE_TYPE}";
 
@@ -61,7 +61,7 @@ namespace JECS.ParsingLogic
             return returnThis;
         }
 
-        internal static IEnumerable<ClassMember> GetValidMembers(this Type type)
+        public static IEnumerable<ClassMember> GetValidMembers(this Type type)
         {
             var members = new List<ClassMember>();
 


### PR DESCRIPTION
This exposes a function that seems to be used for iterating over all properties that are being serialized by JECS. 

Exposing this allows users to easily iterate over said fields also instead of having to cook up custom reflection code that might have different behaviour between JECS versions, in case this function ever changes.