### PR TITLE
Cleanup and refactor

### DIFF
--- a/JECS.Tests/ComplexType.cs
+++ b/JECS.Tests/ComplexType.cs
@@ -20,11 +20,11 @@ namespace JECS.Tests
         public override bool Equals(object obj)
         {
             var other = (ComplexType)obj;
-            if (other == null) 
+            if (other == null)
                 return false;
 
-            return this.Integer == other.Integer 
-                && this.String == other.String 
+            return this.Integer == other.Integer
+                && this.String == other.String
                 && this.Boolean == other.Boolean;
         }
 
@@ -39,7 +39,7 @@ namespace JECS.Tests
 
 
 
-        public static ComplexType PropertyShortcut 
+        public static ComplexType PropertyShortcut
             => new ComplexType(0, "string", false);
 
         public static ComplexType MethodShortcut(int integer, string text, bool boolean)

--- a/JECS.Tests/Invalid file structure tests/InvalidFileStructureTests.cs
+++ b/JECS.Tests/Invalid file structure tests/InvalidFileStructureTests.cs
@@ -100,6 +100,16 @@ namespace JECS.Tests
         }
 
         [TestMethod]
+        public void InvalidFileStructure_MultiLineString_MissingTerminator_AtEndOfFile()
+        {
+            const string fileText = """"
+                key: """
+                    multi-line string
+                """";
+            TestUtilities.PerformInvalidFileStructureTest(fileText);
+        }
+
+        [TestMethod]
         public void InvalidFileStructure_MultiLineString_MismatchedBodyIndents()
         {
             const string fileText = """"

--- a/JECS.Tests/Invalid file structure tests/InvalidFileStructureTests.cs
+++ b/JECS.Tests/Invalid file structure tests/InvalidFileStructureTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using JECS.MemoryFiles;
 
 namespace JECS.Tests
 {
@@ -9,67 +8,67 @@ namespace JECS.Tests
         [TestMethod]
         public void InvalidFileStructure_NoKeyValue()
         {
-            const string fileText = @"
-this line doesn't have a colon to indicate key/value
-";
+            const string fileText = """
+                this line doesn't have a colon to indicate key/value
+                """;
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_DuplicateTopLevelKeys()
         {
-            const string fileText = @"
-key: value
-key: value2
-";
+            const string fileText = """
+                key: value
+                key: value2
+                """;
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_DuplicateNestedKeys()
         {
-            const string fileText = @"
-key:
-    key2: lol
-    key2: cum
-";
+            const string fileText = """
+                key:
+                    key2: lol
+                    key2: cum
+                """;
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_MismatchedSiblingIndents_Back()
         {
-            const string fileText = @"
-key:
-    key2: lol
-   key3: cum
-";
+            const string fileText = """
+                key:
+                    key2: lol
+                   key3: cum
+                """;
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_MismatchedSiblingIndents_Forward()
         {
-            const string fileText = @"
-key:
-    key2: lol
-     key3: cum
-";
+            const string fileText = """
+                key:
+                    key2: lol
+                     key3: cum
+                """;
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_TopLevelListNodes()
         {
-            const string fileText = @"
-key: value
-Key2: value2
-key3:
-    - regular
-    - list
+            const string fileText = """
+                key: value
+                Key2: value2
+                key3:
+                    - regular
+                    - list
 
-- floating list node
-";
+                - floating list node
+                """;
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
@@ -78,51 +77,51 @@ key3:
         [TestMethod]
         public void InvalidFileStructure_MultiLineString_NoBody()
         {
-            const string fileText = @"
-key: """"""
+            const string fileText = """"
+                key: """
 
-key2: value
-";
+                key2: value
+                """";
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_MultiLineString_MissingTerminator()
         {
-            const string fileText = @"
-key: """"""
-    multi-line string
-    but it doesn't have a terminator!
-    fuck!
+            const string fileText = """"
+                key: """
+                    multi-line string
+                    but it doesn't have a terminator!
+                    fuck!
 
-key2: value
-";
+                key2: value
+                """";
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_MultiLineString_MismatchedBodyIndents()
         {
-            const string fileText = @"
-key: """"""
-    multi-line string
-        but the indents are screwy
-    fuck!
-    """"""
-";
+            const string fileText = """"
+                key: """
+                    multi-line string
+                        but the indents are screwy
+                    fuck!
+                    """
+                """";
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 
         [TestMethod]
         public void InvalidFileStructure_MultiLineString_MismatchedTerminatorIndent()
         {
-            const string fileText = @"
-key: """"""
-    multi-line string
-        but the terminator indent is
-    fuck!
-       """"""
-";
+            const string fileText = """"
+                key: """
+                    multi-line string
+                        but the terminator indent is
+                    fuck!
+                       """
+                """";
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
 

--- a/JECS.Tests/Invalid file structure tests/InvalidFileStructureTests.cs
+++ b/JECS.Tests/Invalid file structure tests/InvalidFileStructureTests.cs
@@ -125,5 +125,18 @@ key: """"""
 ";
             TestUtilities.PerformInvalidFileStructureTest(fileText);
         }
+
+        [TestMethod]
+        public void InvalidFileStructure_WrongKeyNodeRootIndentation()
+        {
+            const string fileText = """
+                      key1: 1
+                   key2: 2
+                  key3: 3
+                 key4: 4
+                key5: 5
+                """;
+            TestUtilities.PerformInvalidFileStructureTest(fileText);
+        }
     }
 }

--- a/JECS.Tests/NodeAccessTests/NodeDeletionTests.cs
+++ b/JECS.Tests/NodeAccessTests/NodeDeletionTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Text;
+using JECS.MemoryFiles;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JECS.Tests.NodeAccessTests
+{
+    [TestClass]
+    public class NodeDeletionTests
+    {
+        private const string SomeDefaultJECS = """"
+            top1:
+                key1:
+                    key1:
+                        key1: lol
+                        key2: asdf
+                  # Yes!
+                    key2: 1234
+            top2: 1234
+               # Lel!
+            top3: #awfawf
+                                  
+                key1: awdawf
+                key2: 435
+            """";
+
+        [TestMethod]
+        [DataRow(SomeDefaultJECS, "top1.key1.key1", 2, 5, DisplayName = "#1")]
+        [DataRow(SomeDefaultJECS, "top3.key2", 12, 12, DisplayName = "#2")]
+        [DataRow(SomeDefaultJECS, "top1.key1", 1, 6, DisplayName = "#3")]
+        public void TestNodeDeletion(string input, string pathConcat, int startDeleteInclusive, int endDeleteInclusive)
+        {
+            Console.WriteLine("Raw:");
+            TestUtilities.PrintJecsLined(input);
+            var dataFile = new MemoryDataFile(input);
+
+            Console.WriteLine($"\nDeleting keys: {pathConcat}");
+            dataFile.DeleteKeyAtPath(pathConcat.Split('.'));
+
+            string output = dataFile.GetRawText();
+            Console.WriteLine("Result:");
+            TestUtilities.PrintJecsLined(output);
+
+            Console.WriteLine($"\nDeleting rows: {startDeleteInclusive} to {endDeleteInclusive} (inclusive)");
+            string expected = DeleteRows(input, startDeleteInclusive, endDeleteInclusive);
+            Console.WriteLine("Expected:");
+            TestUtilities.PrintJecsLined(expected);
+
+            Assert.AreEqual(expected, output);
+        }
+
+        private string DeleteRows(string raw, int startDeleteInclusive, int endDeleteInclusive)
+        {
+            string[] lines = raw.Split('\n');
+            var builder = new StringBuilder();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (i < startDeleteInclusive || i > endDeleteInclusive)
+                    builder.AppendLine(lines[i]);
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/JECS.Tests/NodeAccessTests/NodeResetTests.cs
+++ b/JECS.Tests/NodeAccessTests/NodeResetTests.cs
@@ -1,0 +1,196 @@
+﻿using System;
+using System.Text;
+using JECS.MemoryFiles;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JECS.Tests.NodeAccessTests
+{
+    [TestClass]
+    public class NodeResetTests
+    {
+        private const string SomeStarterJECS = """"
+            top1:
+                key1:
+                    key1:
+                        key1: lol
+                        key2: asdf
+                  # Yes!
+                    key2: 1234
+            top2: 1234
+               # Lel!
+            top3: #awfawf
+                                  
+                key1: awdawf
+                key2: 435
+                key3: I am not in the default!
+            """";
+
+        private const string SomeDefaultJECS = """"
+            top1:
+                key1:
+                    someOtherDefaultKey: """
+                        With some text :)
+                        """
+                    key1:
+                        key1: lol
+                        defaultKey: asdf
+                    key2: 1234
+            top2: 8432
+            top4: false # My man, speak truth!
+            top3:
+                key1:
+                    - 123
+                    - 4456
+                key2: 435
+            """";
+
+        [TestMethod]
+        [DataRow(SomeStarterJECS, SomeDefaultJECS, "top1.key1.someOtherDefaultKey", 7, -1, 2, 4, DisplayName = "#1: Reset something")]
+        [DataRow(SomeStarterJECS, SomeDefaultJECS, "top1", 0, 6, 0, 8, DisplayName = "#2: Reset top-level")]
+        [DataRow(SomeStarterJECS, SomeDefaultJECS, "top4", 14, -1, 10, 10, DisplayName = "#3: Append missing top-level")]
+        [DataRow(SomeStarterJECS, SomeDefaultJECS, "top3.key3", 13, 13, 0, -1, DisplayName = "#4: Delete no-default key")]
+        public void TestNodeReset(
+            string inputJecs, string defaultJecs, string pathToReset,
+            int startReplaceWith, int endReplaceWith,
+            int startReplaceFrom, int endReplaceFrom)
+        {
+            Console.WriteLine("Raw:");
+            TestUtilities.PrintJecsLined(inputJecs);
+            var dataFile = new MemoryDataFile(inputJecs, "", defaultJecs);
+
+            Console.WriteLine($"\nReset path: {pathToReset}");
+            dataFile.ResetValueAtPathToDefault(pathToReset.Split('.'));
+
+            string output = dataFile.GetRawText();
+            Console.WriteLine("Result:");
+            TestUtilities.PrintJecsLined(output);
+
+            Console.WriteLine($"\nReplacing rows {startReplaceWith} to {endReplaceWith} replace with {startReplaceFrom} to {endReplaceFrom}");
+            string expected = ReplaceRows(inputJecs, defaultJecs, startReplaceWith, endReplaceWith, startReplaceFrom, endReplaceFrom);
+            Console.WriteLine("Expected:");
+            TestUtilities.PrintJecsLined(expected);
+
+            Assert.AreEqual(expected, output);
+        }
+
+        private static string ReplaceRows(string raw, string replacement,
+            int startReplaceWith, int endReplaceWith,
+            int startReplaceFrom, int endReplaceFrom)
+        {
+            string[] lines = raw.Split('\n');
+            string[] replacementLines = replacement.Split('\n');
+            var builder = new StringBuilder();
+            for (int i = 0; i < lines.Length; i++)
+            {
+                // Once we encounter the very first line to replace, we inject all the replacement immediately.
+                if (i == startReplaceWith)
+                {
+                    for (int r = startReplaceFrom; r <= endReplaceFrom; r++)
+                        builder.AppendLine(replacementLines[r]);
+                }
+
+                // endReplaceWith is <0 for the no-replacement just-inject mode.
+                // And in that mode injection happens before the index - weird - but this is only for this test.
+                if (endReplaceWith < 0 || i < startReplaceWith || i > endReplaceWith)
+                    builder.AppendLine(lines[i]);
+            }
+            if (lines.Length == startReplaceWith)
+            {
+                for (int r = startReplaceFrom; r <= endReplaceFrom; r++)
+                    builder.AppendLine(replacementLines[r]);
+            }
+            return builder.ToString();
+        }
+
+        private const string IndentationStarterJECS = """"
+            originallyWide:
+             sub:
+              key: value
+              # Preserved for test structure.
+              other: value
+            originallySmall:
+                    sub:
+                        key: value
+                        other: value
+            """";
+
+        private const string IndentationDefaultJECS = """"
+            originallyWide:
+                    sub:
+                            key: value
+             # Hey, I cannot be moved into negative :)
+                            other: value
+            originallySmall:
+             sub:
+              key: value
+              other: value
+            """";
+
+        [TestMethod]
+        [DataRow(IndentationStarterJECS, IndentationDefaultJECS, "originallyWide.sub", 1, 4, -7, DisplayName = "#1: Remove indentation (but not into negative)")]
+        [DataRow(IndentationStarterJECS, IndentationDefaultJECS, "originallySmall.sub", 6, 8, +7, DisplayName = "#2: Add indentation")]
+        public void TestNodeReset_Indentation(
+            string inputJecs, string defaultJecs, string pathToReset,
+            int linesStart, int linesEnd, int indentationDelta)
+        {
+            Console.WriteLine("Raw:");
+            TestUtilities.PrintJecsLined(inputJecs);
+            var dataFile = new MemoryDataFile(inputJecs, "", defaultJecs);
+
+            Console.WriteLine($"\nReset path: {pathToReset}");
+            dataFile.ResetValueAtPathToDefault(pathToReset.Split('.'));
+
+            string output = dataFile.GetRawText();
+            Console.WriteLine("Result:");
+            TestUtilities.PrintJecsLined(output);
+
+            Console.WriteLine($"\nRegion rows {linesStart} to {linesEnd} with indentation delta {indentationDelta}");
+            string expected;
+            {
+                string[] inputLines = inputJecs.Split('\n');
+                string[] defaultLines = defaultJecs.Split('\n');
+                var builder = new StringBuilder();
+
+                for (int lineIndex = 0; lineIndex < inputLines.Length; lineIndex++)
+                {
+                    if (lineIndex < linesStart || lineIndex > linesEnd)
+                    {
+                        builder.AppendLine(inputLines[lineIndex]);
+                        continue;
+                    }
+
+                    string line = defaultLines[lineIndex];
+                    if (indentationDelta < 0)
+                    {
+                        // Remove indentation
+                        int innerIndentationDelta = -indentationDelta;
+                        // Sadly this code is copied directly from the code which we are testing...
+                        // If you know a better way, please update it.
+                        int actualRemoval = 0;
+                        for (int charIndex = 0; charIndex < innerIndentationDelta && charIndex < line.Length; charIndex++)
+                        {
+                            if (line[charIndex] != ' ')
+                                break;
+                            actualRemoval += 1;
+                        }
+                        line = line[actualRemoval..];
+                    }
+                    else
+                    {
+                        // Add indentation:
+                        line = new string(' ', indentationDelta) + line;
+                    }
+                    builder.AppendLine(line);
+                }
+
+                expected = builder.ToString();
+            }
+            Console.WriteLine("Expected:");
+            TestUtilities.PrintJecsLined(expected);
+
+            Console.WriteLine("\n-prevent trim-");
+
+            Assert.AreEqual(expected, output);
+        }
+    }
+}

--- a/JECS.Tests/Parsing error tests/InvalidArrayDataTests.cs
+++ b/JECS.Tests/Parsing error tests/InvalidArrayDataTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using JECS.MemoryFiles;
 
 namespace JECS.Tests
 {
@@ -9,47 +8,47 @@ namespace JECS.Tests
         [TestMethod]
         public void InvalidFileData_InvalidArrayData_NodeHasValue()
         {
-            const string fileText = @"
-data: lol this isn't an int array
-";
+            const string fileText = """
+                data: lol this isn't an int array
+                """;
             TestUtilities.PerformParsingErrorTest<int[]>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidArrayData_InvalidListItemNode()
         {
-            const string fileText = @"
-data:
-    - 0
-    - 1
-    - cum
-    - 69
-";
+            const string fileText = """
+                data:
+                    - 0
+                    - 1
+                    - cum
+                    - 69
+                """;
             TestUtilities.PerformParsingErrorTest<int[]>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidArrayData_InvalidNestedCollection()
         {
-            const string fileText = @"
-data:
-    - 22
-    - 121
-    -
-        - 55
-        - 6969
-    - 11
-";
+            const string fileText = """
+                data:
+                    - 22
+                    - 121
+                    -
+                        - 55
+                        - 6969
+                    - 11
+                """;
             TestUtilities.PerformParsingErrorTest<int[]>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidArrayData_InvalidKeyChildren()
         {
-            const string fileText = @"
-data:
-    child: node
-";
+            const string fileText = """
+                data:
+                    child: node
+                """;
             TestUtilities.PerformParsingErrorTest<int[]>(fileText);
         }
     }

--- a/JECS.Tests/Parsing error tests/InvalidBaseTypeNodeDataTests.cs
+++ b/JECS.Tests/Parsing error tests/InvalidBaseTypeNodeDataTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using JECS.MemoryFiles;
 
 namespace JECS.Tests
 {
@@ -9,20 +8,20 @@ namespace JECS.Tests
         [TestMethod]
         public void InvalidFileData_InvalidBaseType_InvalidNodeValue()
         {
-            const string fileText = @"
-data: notanint
-";
+            const string fileText = """
+                data: notanint
+                """;
             TestUtilities.PerformParsingErrorTest<int>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidBaseType_BadSpecialStringCase()
         {
-            const string fileText = @"
-data: """"""
-    lmao it's a string
-    """"""
-";
+            const string fileText = """"
+                data: """
+                    lmao it's a string
+                    """
+                """";
             TestUtilities.PerformParsingErrorTest<int>(fileText);
         }
     }

--- a/JECS.Tests/Parsing error tests/InvalidComplexTypeDataTests.cs
+++ b/JECS.Tests/Parsing error tests/InvalidComplexTypeDataTests.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using JECS.MemoryFiles;
-using System.Collections.Generic;
 
 namespace JECS.Tests
 {
@@ -10,78 +8,77 @@ namespace JECS.Tests
         [TestMethod]
         public void InvalidFileData_InvalidComplexTypeData_InvalidShortcut()
         {
-            const string fileText = @"
-data: this is an invalid shortcut lol
-";
+            const string fileText = """
+                data: this is an invalid shortcut lol
+                """;
             TestUtilities.PerformParsingErrorTest<ComplexType>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidComplexTypeData_ConstructorShortcutWithInvalidData()
         {
-            const string fileText = @"
-data: (0, test, cum)
-";
+            const string fileText = """
+                data: (0, test, cum)
+                """;
             TestUtilities.PerformParsingErrorTest<ComplexType>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidComplexTypeData_MethodShortcutWithInvalidData()
         {
-            const string fileText = @"
-data: MethodShortcut(cum, test, false)
-";
+            const string fileText = """
+                data: MethodShortcut(cum, test, false)
+                """;
             TestUtilities.PerformParsingErrorTest<ComplexType>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidComplexTypeData_InvalidDataInChildren()
         {
-            const string fileText = @"
-data:
-    Integer: 69
-    String: sex
-    Boolean: invalid
-";
+            const string fileText = """
+                data:
+                    Integer: 69
+                    String: sex
+                    Boolean: invalid
+                """;
             TestUtilities.PerformParsingErrorTest<ComplexType>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidComplexTypeData_ChildrenAreListNodes()
         {
-            const string fileText = @"
-data:
-    - lol
-    - it's a list lol
-";
+            const string fileText = """
+                data:
+                    - lol
+                    - it's a list lol
+                """;
             TestUtilities.PerformParsingErrorTest<ComplexType>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidComplexTypeData_ChildrenAreMultiLineString()
         {
-            const string fileText = @"
-data: """"""
-    this is a string haha
-    indeed, it's a multi-line string!
-    """"""
-";
+            const string fileText = """"
+                data: """
+                    this is a string haha
+                    indeed, it's a multi-line string!
+                    """
+                """";
             TestUtilities.PerformParsingErrorTest<ComplexType>(fileText);
         }
 
 
-        const string ValidFileStructure_InvalidComplexTypeData = @"
+        const string ValidFileStructure_InvalidComplexTypeData = """"
 
+            ComplexType5:
+                - lol
+                - it's a list lol
 
-ComplexType5:
-    - lol
-    - it's a list lol
+            ComplexType6: """
+                this is a string haha
+                indeed, it's a multi-line string!
+                """
 
-ComplexType6: """"""
-    this is a string haha
-    indeed, it's a multi-line string!
-    """"""
-
-";
+            """";
     }
 }

--- a/JECS.Tests/Parsing error tests/InvalidDictionaryDataTests.cs
+++ b/JECS.Tests/Parsing error tests/InvalidDictionaryDataTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using JECS.MemoryFiles;
 using System.Collections.Generic;
 
 namespace JECS.Tests
@@ -10,60 +9,60 @@ namespace JECS.Tests
         [TestMethod]
         public void InvalidFileData_InvalidDictionaryData_NodeHasValue()
         {
-            const string fileText = @"
-data: lol this isn't a dictionary
-";
+            const string fileText = """
+                data: lol this isn't a dictionary
+                """;
             TestUtilities.PerformParsingErrorTest<Dictionary<string, int>>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidDictionaryData_HasWrongListForChildren()
         {
-            const string fileText = @"
-data:
-    - 0
-    - 1
-    - 69
-";
+            const string fileText = """
+                data:
+                    - 0
+                    - 1
+                    - 69
+                """;
             TestUtilities.PerformParsingErrorTest<Dictionary<string, int>>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidDictionaryData_OneInvalidValue()
         {
-            const string fileText = @"
-data:
-    key: 12
-    key2: 35
-    key3: sex
-";
+            const string fileText = """
+                data:
+                    key: 12
+                    key2: 35
+                    key3: sex
+                """;
             TestUtilities.PerformParsingErrorTest<Dictionary<string, int>>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidDictionaryData_OneInvalidKey()
         {
-            const string fileText = @"
-data:
-    12: value
-    25: value2
-    sex: value3
-";
+            const string fileText = """
+                data:
+                    12: value
+                    25: value2
+                    sex: value3
+                """;
             TestUtilities.PerformParsingErrorTest<Dictionary<int, string>>(fileText);
         }
 
         [TestMethod]
         public void InvalidFileData_InvalidDictionaryData_InvalidArrayDictionary()
         {
-            const string fileText = @"
-data:
-    -
-        key: sex
-        value: 420
-    -
-        key: balls
-        value: ass
-";
+            const string fileText = """
+                data:
+                    -
+                        key: sex
+                        value: 420
+                    -
+                        key: balls
+                        value: ass
+                """;
             TestUtilities.PerformParsingErrorTest<Dictionary<string, int>>(fileText);
         }
     }

--- a/JECS.Tests/Parsing success tests/ValidMultiLineStringTests.cs
+++ b/JECS.Tests/Parsing success tests/ValidMultiLineStringTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using JECS.MemoryFiles;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JECS.Tests
+{
+    [TestClass]
+    public class ValidMultiLineStringTests
+    {
+        [TestMethod]
+        [DataRow("", DisplayName = "MLS Empty")]
+        [DataRow("""
+
+
+            """, DisplayName = "MLS 2 Empty Lines")]
+        public void MultiLineStringSimple(string testString)
+            => TestMultiLineString(testString, testString);
+
+        [TestMethod]
+        [DataRow("""
+                 # Test
+                 """, DisplayName = "Comment test")]
+        [DataRow("""
+                 "  okay lol :D  " # Test
+                 # Magic potatoes!
+                 Ay "Noise " # ASDF!
+                 """, DisplayName = "Comment test with quotes")]
+        public void MultiLineStringStrippedComments(string testString)
+        {
+            // This test will modify our input string to strip comments in a simple way.
+            // The idea is that JECS is able to do the same by itself.
+            // WARNING: No trailing / support yet!
+            var strippedTestString = string.Join('\n', testString.Split('\n').Select(line =>
+            {
+                // First replace all # signs that would be escaped with an illegal character (tab)
+                var rawLine = line.Replace("\\#", "\t");
+
+                // Then find and remove # with everything after (removal of comments)
+                var indexOfComment = rawLine.IndexOf('#');
+                if (indexOfComment >= 0)
+                    rawLine = rawLine[..indexOfComment];
+
+                // Finally reverse the escaped # replacement and trim the line to get the actual data
+                rawLine = rawLine.Replace("\t", "\\#").Trim();
+
+                // Crop quotation (if any)
+                if (rawLine.StartsWith('"') && rawLine.EndsWith('"'))
+                    rawLine = rawLine[1..^1];
+
+                return rawLine;
+            }));
+
+            TestMultiLineString(strippedTestString, testString);
+        }
+
+        private void TestMultiLineString(string actualExpectedTextContent, string testToWrapWithJecs)
+        {
+            Console.WriteLine($"Original: >>>{actualExpectedTextContent}<<<\n");
+
+            // Base text indentation of 1, so that empty strings are supported.
+            var content = string.Join('\n', testToWrapWithJecs.Split('\n').Select(line => $" {line}")) + '\n';
+            var jecsRaw = $""""
+                key: """
+                {content} """
+                """";
+            Console.WriteLine($"JECS: >>>\n{jecsRaw}\n<<<\n");
+
+            var file = new MemoryReadOnlyDataFile(jecsRaw);
+            var parsedString = file.Get<string>("key");
+            Console.WriteLine($"Parsed: >>>{parsedString}<<<");
+
+            Assert.AreEqual(parsedString, actualExpectedTextContent);
+        }
+    }
+}

--- a/JECS.Tests/SaveLoad tests/Base Types/SaveLoad_DateTimeTests.cs
+++ b/JECS.Tests/SaveLoad tests/Base Types/SaveLoad_DateTimeTests.cs
@@ -7,13 +7,13 @@ namespace JECS.Tests
     public class SaveLoad_DateTimeTests
     {
         [TestMethod]
-        public void SaveLoad_DateTime_MinValue() 
+        public void SaveLoad_DateTime_MinValue()
             => TestUtilities.PerformSaveLoadTest(DateTime.MinValue);
 
         // don't test with DateTime.MaxValue. It doesn't work for some reason, idk why, but it's *probably* not JECS's fault.
 
         [TestMethod]
-        public void SaveLoad_DateTime_MyBirthday() 
+        public void SaveLoad_DateTime_MyBirthday()
             => TestUtilities.PerformSaveLoadTest(new DateTime(2000, 07, 21));
     }
 }

--- a/JECS.Tests/SaveLoad tests/Base Types/SaveLoad_EnumTests.cs
+++ b/JECS.Tests/SaveLoad tests/Base Types/SaveLoad_EnumTests.cs
@@ -64,35 +64,35 @@ namespace JECS.Tests
 
 
         public enum TestEnumInt : int
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumLong : long
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumShort : short
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumUint : uint
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumUlong : ulong
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumUshort : ushort
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumByte : byte
-        { 
+        {
             TestValue = 0
         }
         public enum TestEnumSbyte : sbyte
-        { 
+        {
             TestValue = 0
         }
     }

--- a/JECS.Tests/SaveLoad tests/Base Types/SaveLoad_StringTests.cs
+++ b/JECS.Tests/SaveLoad tests/Base Types/SaveLoad_StringTests.cs
@@ -44,107 +44,107 @@ namespace JECS.Tests
         public void SaveLoad_String_NewLinex3()
             => TestUtilities.PerformSaveLoadTest(Environment.NewLine + Environment.NewLine + Environment.NewLine);
 
-        const string multiLineString = @"
-this is a
-string with multiple lines
-";
+        const string multiLineString = """
+            this is a
+            string with multiple lines
+            """;
 
-        const string multiLineStringWithPoundSigns = @"
-this is a
-string with multiple lines
-and #pound #signs
-####
-#yolo
-yolo#
-";
+        const string multiLineStringWithPoundSigns = """
+            this is a
+            string with multiple lines
+            and #pound #signs
+            ####
+            #yolo
+            yolo#
+            """;
 
-        const string multiLineStringWithDoubleQuotes = @"
-this is a
-string with multiple lines
-and ""double quotes""
-""""
-""""""
-""yolo
-yolo""
-""yolo""
-";
+        const string multiLineStringWithDoubleQuotes = """"
+            this is a
+            string with multiple lines
+            and "double quotes"
+            ""
+            """
+            "yolo
+            yolo"
+            "yolo"
+            """";
 
-        const string multiLineStringWithLeadingTrailingSpaces = @"
-this is a
-string with multiple lines
-   and leading spaces
-and trailing spaces    
-    and both!    
-";
+        const string multiLineStringWithLeadingTrailingSpaces = """
+            this is a
+            string with multiple lines
+               and leading spaces
+            and trailing spaces    
+                and both!    
+            """;
 
-        const string multiLineStringWithBackslashes = @"
+        const string multiLineStringWithBackslashes = """
 
-\
+            \
 
-\\
+            \\
 
-\\\\\
+            \\\\\
 
-""\""
+            "\"
 
-";
+            """;
 
         const string veryLongString = "What the fuck did you just fucking say about me, you little bitch? I'll have you know I graduated top of my public class in the Navy Seals, and I've been involved in numerous secret raids on Al-Quaeda, and I have over 300 confirmed kills. I am trained in gorilla warfare and I'm the top sniper in the entire US armed forces. You are nothing to me but just another target. I will wipe you the fuck out with precision the likes of which has never been seen before on this Earth, mark my fucking words. You think you can get away with saying that shit to me over the Internet? Think again, fucker. As we speak I am contacting my secret network of spies across the USA and your IP is being traced right now so you better prepare for the storm, maggot. The storm that wipes out the pathetic little thing you call your life. You're fucking dead, kid. I can be anywhere, anytime, and I can kill you in over seven hundred ways, and that's just with my bare hands. Not only am I extensively trained in unarmed combat, but I have access to the entire arsenal of the United States Marine Corps and I will use it to its full extent to wipe your miserable ass off the face of the continent, you little shit. If only you could have known what unholy retribution your little \"clever\" comment was about to bring down upon you, maybe you would have held your fucking tongue. But you couldn't, you didn't, and now you're paying the price, you goddamn idiot. I will shit fury all over you and you will drown in it. You're fucking dead, kiddo.";
 
-        // [i carry your heart with me(i carry it in] 
+        // [i carry your heart with me(i carry it in]
         // by E. E. Cummings
-        const string poem = @"
-i carry your heart with me(i carry it in
-my heart)i am never without it(anywhere
-i go you go,my dear;and whatever is done
-by only me is your doing,my darling)
-                                                      i fear
-no fate(for you are my fate,my sweet)i want
-no world(for beautiful you are my world,my true)
-and it’s you are whatever a moon has always meant
-and whatever a sun will always sing is you
+        const string poem = """
+            i carry your heart with me(i carry it in
+            my heart)i am never without it(anywhere
+            i go you go,my dear;and whatever is done
+            by only me is your doing,my darling)
+                                                                  i fear
+            no fate(for you are my fate,my sweet)i want
+            no world(for beautiful you are my world,my true)
+            and it’s you are whatever a moon has always meant
+            and whatever a sun will always sing is you
 
-here is the deepest secret nobody knows
-(here is the root of the root and the bud of the bud
-and the sky of the sky of a tree called life;which grows
-higher than soul can hope or mind can hide)
-and this is the wonder that's keeping the stars apart
+            here is the deepest secret nobody knows
+            (here is the root of the root and the bud of the bud
+            and the sky of the sky of a tree called life;which grows
+            higher than soul can hope or mind can hide)
+            and this is the wonder that's keeping the stars apart
 
-i carry your heart(i carry it in my heart)
-";
-        const string genemoji = @"
-1 In the beginning🌄 God ⛏️🛠️created⚒️🔨 the heavens🌤️ and the 🌍🌎earth🌏🗺️. 2 Now the 🌍🌎earth🌏🗺️ was formless and empty, 🌚darkness🌚 was over the surface of the deep, and the 👻Spirit👻 of God was hovering over the 🌊💧waters💦💦💦.
+            i carry your heart(i carry it in my heart)
+            """;
+        const string genemoji = """
+            1 In the beginning🌄 God ⛏️🛠️created⚒️🔨 the heavens🌤️ and the 🌍🌎earth🌏🗺️. 2 Now the 🌍🌎earth🌏🗺️ was formless and empty, 🌚darkness🌚 was over the surface of the deep, and the 👻Spirit👻 of God was hovering over the 🌊💧waters💦💦💦.
 
-3 And God said🗣️, “Let there be🐝 light💡,” and there was light💡. 4 God saw👁️ that the 🌝light🌝 was good👍👌👌, and he separated the 🌝light🌝 from the 🌚darkness🌚. 5 God called📞 the 🌝light🌝 “day☀️,” and the 🌚darkness🌚 he called📞 “night🌙.” And there was 🌙evening, and there was ☀️morning—the 🥇first ☀️day☀️.
+            3 And God said🗣️, “Let there be🐝 light💡,” and there was light💡. 4 God saw👁️ that the 🌝light🌝 was good👍👌👌, and he separated the 🌝light🌝 from the 🌚darkness🌚. 5 God called📞 the 🌝light🌝 “day☀️,” and the 🌚darkness🌚 he called📞 “night🌙.” And there was 🌙evening, and there was ☀️morning—the 🥇first ☀️day☀️.
 
-6 And God said🗣️, “Let there be🐝 a🅰️ vault ➡️between⬅️ the 🌊💧waters💦💦 to2️⃣ separate 🌊💧water💦💦 from 🌊💧water💦💦.” 7 So God ⛏️⚒️made🛠️🔨 the vault and separated the 🌊💧water💦💦 under the vault from the 🌊💧water💦💦 above it. And it was so. 8 God called📞 the vault “sky🌥️.” And there was 🌙evening, and there was ☀️morning—the 🥈second ☀️day☀️.
+            6 And God said🗣️, “Let there be🐝 a🅰️ vault ➡️between⬅️ the 🌊💧waters💦💦 to2️⃣ separate 🌊💧water💦💦 from 🌊💧water💦💦.” 7 So God ⛏️⚒️made🛠️🔨 the vault and separated the 🌊💧water💦💦 under the vault from the 🌊💧water💦💦 above it. And it was so. 8 God called📞 the vault “sky🌥️.” And there was 🌙evening, and there was ☀️morning—the 🥈second ☀️day☀️.
 
-9 And God said🗣️, “Let the 🌊💧water💦💦 under the 🌥️sky be🐝 gathered to2️⃣ one1️⃣ place, and let dry🌵 ground appear.” And it was so. 10 God called📞 the dry ground “land🗺️,” and the gathered 🌊💧waters💦💦 he called📞 “seas🗺️.” And God saw👁️ that it was good👍👌👌.
+            9 And God said🗣️, “Let the 🌊💧water💦💦 under the 🌥️sky be🐝 gathered to2️⃣ one1️⃣ place, and let dry🌵 ground appear.” And it was so. 10 God called📞 the dry ground “land🗺️,” and the gathered 🌊💧waters💦💦 he called📞 “seas🗺️.” And God saw👁️ that it was good👍👌👌.
 
-11 Then God said🗣️, “Let the land🗺️ produce 🌱🌲vegetation🌳🌴: seed-bearing plants🌱 and 🌲🌳trees🌴🌴 on the land🗺️ that bear 🍇🍈🍉🍊🍋🍌🍍fruit🍎🍏🍐🍑🍒🍓🥝 with seed in it, according to2️⃣ their various kinds.” And it was so. 12 The land🗺️ produced 🌱🌲vegetation🌳🌴: plants🌱 bearing seed according to2️⃣ their kinds and 🌲🌳trees🌴🌴 🐻bearing🐼 🍇🍈🍉🍊🍋🍌🍍fruit🍎🍏🍐🍑🍒🍓🥝 with seed in it according to2️⃣ their kinds. And God saw👁️ that it was good👍👌👌. 13 And there was evening🌙, and there was morning☀️—the 🥉third ☀️day☀️.
+            11 Then God said🗣️, “Let the land🗺️ produce 🌱🌲vegetation🌳🌴: seed-bearing plants🌱 and 🌲🌳trees🌴🌴 on the land🗺️ that bear 🍇🍈🍉🍊🍋🍌🍍fruit🍎🍏🍐🍑🍒🍓🥝 with seed in it, according to2️⃣ their various kinds.” And it was so. 12 The land🗺️ produced 🌱🌲vegetation🌳🌴: plants🌱 bearing seed according to2️⃣ their kinds and 🌲🌳trees🌴🌴 🐻bearing🐼 🍇🍈🍉🍊🍋🍌🍍fruit🍎🍏🍐🍑🍒🍓🥝 with seed in it according to2️⃣ their kinds. And God saw👁️ that it was good👍👌👌. 13 And there was evening🌙, and there was morning☀️—the 🥉third ☀️day☀️.
 
-14 And God said🗣️, “Let there be🐝 🌝lights🌝 in the vault of the sky🌥️ to2️⃣ separate the ☀️day☀️ from the 🌙night🌙, and let them serve as signs to2️⃣ mark sacred ⌚⏰⏱️times⏲️🕰️🕛, and days📆 and years📅, 15 and let them be🐝 🌝lights🌝 in the vault of the sky🌥️ to2️⃣ give 🌝light🌝 on the 🌍🌎earth🌏🗺️.” And it was so. 16 God ⛏️⚒️made🛠️🔨 two2️⃣ great 🌝lights🌝—the greater 🌞light☀️ to govern the ☀️day☀️ and the lesser 🌛light🌜 to govern the 🌙night🌙. He also made the ✨stars✨. 17 God set them in the vault of the sky🌥️ to give 🌝light🌝 on the 🌏🗺️earth🌍🌎, 18 to2️⃣ govern the ☀️day☀️ and the 🌙night🌙, and to2️⃣ separate 🌝light🌝 from 🌚darkness🌚. And God saw👁️ that it was good👍👌👌. 19 And there was evening🌙, and there was morning☀️—the 4️⃣fourth ☀️day☀️.
+            14 And God said🗣️, “Let there be🐝 🌝lights🌝 in the vault of the sky🌥️ to2️⃣ separate the ☀️day☀️ from the 🌙night🌙, and let them serve as signs to2️⃣ mark sacred ⌚⏰⏱️times⏲️🕰️🕛, and days📆 and years📅, 15 and let them be🐝 🌝lights🌝 in the vault of the sky🌥️ to2️⃣ give 🌝light🌝 on the 🌍🌎earth🌏🗺️.” And it was so. 16 God ⛏️⚒️made🛠️🔨 two2️⃣ great 🌝lights🌝—the greater 🌞light☀️ to govern the ☀️day☀️ and the lesser 🌛light🌜 to govern the 🌙night🌙. He also made the ✨stars✨. 17 God set them in the vault of the sky🌥️ to give 🌝light🌝 on the 🌏🗺️earth🌍🌎, 18 to2️⃣ govern the ☀️day☀️ and the 🌙night🌙, and to2️⃣ separate 🌝light🌝 from 🌚darkness🌚. And God saw👁️ that it was good👍👌👌. 19 And there was evening🌙, and there was morning☀️—the 4️⃣fourth ☀️day☀️.
 
-20 And God said🗣️, “Let the 🌊💧water💦💦 teem with living creatures, and let 🦃🐔🐓🐣🕊️🦅birds🐤🐥🐦🐧🦆🦉 fly above🔝 the 🌍🌎earth🌏🗺️ across the vault of the sky🌥️.” 21 So God ⛏️⚒️created🛠️🔨 the great creatures of the 🗺️sea and every living thing with which the 🌊💧water💦💦 teems and that moves about in it, according to2️⃣ their kinds, and every winged 🦃🐔🐓🐣🐤🐥bird🐦🐧🕊️🦅🦆🦉 according to2️⃣ its kind. And God saw👁️ that it was good👍👌👌. 22 God 😇blessed😇 them and said🗣️, “Be 🍇🍈🍉🍊🍋🍌🍍fruitful🍎🍏🍐🍑🍒🍓🥝 and increase➕ in number#️⃣ and fill the 🌊💧water💦💦 in the seas🗺️, and let the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 increase➕ on🔛 the 🌍🌎earth🌏🗺️.” 23 And there was evening🌙, and there was morning☀️—the 5️⃣fifth ☀️day☀️.
+            20 And God said🗣️, “Let the 🌊💧water💦💦 teem with living creatures, and let 🦃🐔🐓🐣🕊️🦅birds🐤🐥🐦🐧🦆🦉 fly above🔝 the 🌍🌎earth🌏🗺️ across the vault of the sky🌥️.” 21 So God ⛏️⚒️created🛠️🔨 the great creatures of the 🗺️sea and every living thing with which the 🌊💧water💦💦 teems and that moves about in it, according to2️⃣ their kinds, and every winged 🦃🐔🐓🐣🐤🐥bird🐦🐧🕊️🦅🦆🦉 according to2️⃣ its kind. And God saw👁️ that it was good👍👌👌. 22 God 😇blessed😇 them and said🗣️, “Be 🍇🍈🍉🍊🍋🍌🍍fruitful🍎🍏🍐🍑🍒🍓🥝 and increase➕ in number#️⃣ and fill the 🌊💧water💦💦 in the seas🗺️, and let the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 increase➕ on🔛 the 🌍🌎earth🌏🗺️.” 23 And there was evening🌙, and there was morning☀️—the 5️⃣fifth ☀️day☀️.
 
-24 And God said🗣️, “Let the 🗺️land produce living creatures according to2️⃣ their kinds: the 🐮🐄🐷🐖🐗🐪🐫livestock🐏🐑🐔🐓🐣🐤🐥, the creatures that move along the 🐫🐪ground🐴🐎, and the 🐬🐟🦈🐙🐨🐼🐺🦊🦁🐯wild🦀🐍🐧🦌🐘 🦏🐿️🦅🦑🐊animals🐌🦂🦇🐻🐅🐆🐒🦍🐳🐋, each according to2️⃣ its kind.” And it was so. 25 God ⛏️⚒️made🛠️🔨 the 🐬🐟🦈🐙🐨🐼🐺🦊🦁🐯wild🦀🐍🐧🦌🐘 🦏🐿️🦅🦑🐊animals🐌🦂🦇🐻🐅🐆🐒🦍🐳🐋 according to2️⃣ their kinds, the 🐮🐄🐷🐖🐗🐪🐫livestock🐏🐑🐔🐓🐣🐤🐥 according to2️⃣ their kinds, and all the creatures that move along the ground according to2️⃣ their kinds. And God saw👁️ that it was good👍👌👌.
+            24 And God said🗣️, “Let the 🗺️land produce living creatures according to2️⃣ their kinds: the 🐮🐄🐷🐖🐗🐪🐫livestock🐏🐑🐔🐓🐣🐤🐥, the creatures that move along the 🐫🐪ground🐴🐎, and the 🐬🐟🦈🐙🐨🐼🐺🦊🦁🐯wild🦀🐍🐧🦌🐘 🦏🐿️🦅🦑🐊animals🐌🦂🦇🐻🐅🐆🐒🦍🐳🐋, each according to2️⃣ its kind.” And it was so. 25 God ⛏️⚒️made🛠️🔨 the 🐬🐟🦈🐙🐨🐼🐺🦊🦁🐯wild🦀🐍🐧🦌🐘 🦏🐿️🦅🦑🐊animals🐌🦂🦇🐻🐅🐆🐒🦍🐳🐋 according to2️⃣ their kinds, the 🐮🐄🐷🐖🐗🐪🐫livestock🐏🐑🐔🐓🐣🐤🐥 according to2️⃣ their kinds, and all the creatures that move along the ground according to2️⃣ their kinds. And God saw👁️ that it was good👍👌👌.
 
-26 Then God said🗣️, “Let us ⛏️⚒️make🛠️🔨 mankind in our image🖼️, in our likeness, so that they may rule over the 🦈🐙fish🦀🦐 in the sea🗺️ and the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 in the sky🌥️, over the 🐮🐄🐷🐖🐗🐪🐫livestock🐏🐑🐔🐓🐣🐤🐥 and all the 🐬🐟🦈🐙🐨🐼🐺🦊🦁🐯wild🦀🐍🐧🦌🐘 🦏🐿️🦅🦑🐊animals🐌🦂🦇🐻🐅🐆🐒🦍🐳🐋, and over all the creatures that move along the ground.”
+            26 Then God said🗣️, “Let us ⛏️⚒️make🛠️🔨 mankind in our image🖼️, in our likeness, so that they may rule over the 🦈🐙fish🦀🦐 in the sea🗺️ and the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 in the sky🌥️, over the 🐮🐄🐷🐖🐗🐪🐫livestock🐏🐑🐔🐓🐣🐤🐥 and all the 🐬🐟🦈🐙🐨🐼🐺🦊🦁🐯wild🦀🐍🐧🦌🐘 🦏🐿️🦅🦑🐊animals🐌🦂🦇🐻🐅🐆🐒🦍🐳🐋, and over all the creatures that move along the ground.”
 
-27 So God ⛏️⚒️created🛠️🔨 mankind in his own image🖼️,
-    in the image🖼️ of God he ⚒️⛏️created🔨🛠️ them;
-    male♂️ and female♀️ he ⛏️⚒️created🛠️🔨 them.
+            27 So God ⛏️⚒️created🛠️🔨 mankind in his own image🖼️,
+                in the image🖼️ of God he ⚒️⛏️created🔨🛠️ them;
+                male♂️ and female♀️ he ⛏️⚒️created🛠️🔨 them.
 
-28 God 😇blessed😇🙏 them and said🗣️ to2️⃣ them, “Be🐝 🍇🍈🍉🍊🍋🍌🍍fruitful🍎🍏🍐🍑🍒🍓🥝 and increase➕ in number#️⃣; fill the 🌍🌎earth🌏🗺️ and subdue it. Rule over the 🦈🐙fish🦀🦐 in the sea🗺️ and the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 in the sky🌥️ and over every living creature that moves on the ground.”
+            28 God 😇blessed😇🙏 them and said🗣️ to2️⃣ them, “Be🐝 🍇🍈🍉🍊🍋🍌🍍fruitful🍎🍏🍐🍑🍒🍓🥝 and increase➕ in number#️⃣; fill the 🌍🌎earth🌏🗺️ and subdue it. Rule over the 🦈🐙fish🦀🦐 in the sea🗺️ and the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 in the sky🌥️ and over every living creature that moves on the ground.”
 
-29 Then God said🗣️, “I👀 give you every seed-bearing plant🌱 on the face😎 of the whole 🌍🌎earth🌏🗺️ and every 🌲🌳tree🌴🌴 that has 🍇🍈🍉🍊🍋🍌🍍fruit🍎🍏🍐🍑🍒🍓🥝 with seed in it. They will be 🐝yours for4️⃣ 🍉🥕🌶️🍄🥒🥜🍗🍞🥖🍟🥞🧀🌭🌮🥙🥚food🥘🍲🥗🍿🍱🍘🍛🍜🍝🍡🍦🍢🍨🍣🍩🎂🍪🍰☕🥛🍺🍬🍮🥃🍶. 30 And to2️⃣ all the beasts👹👺 of the 🌍🌎earth🌏🗺️ and all the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 in the sky🌥️ and all the creatures that move along the ground—everything that has the breath🌬️ of life in it—I👀 give every 💚green💚 plant🌱 for4️⃣ 🍉🥕🌶️🍄🥒🥜🍗🍞🥖🍟🥞🧀🌭🌮🥙🥚food🥘🍲🥗🍿🍱🍘🍛🍜🍝🍡🍦🍢🍨🍩🎂🍪🍰☕🥛🍺🍬🍮🥃🍶.” And it was so.
+            29 Then God said🗣️, “I👀 give you every seed-bearing plant🌱 on the face😎 of the whole 🌍🌎earth🌏🗺️ and every 🌲🌳tree🌴🌴 that has 🍇🍈🍉🍊🍋🍌🍍fruit🍎🍏🍐🍑🍒🍓🥝 with seed in it. They will be 🐝yours for4️⃣ 🍉🥕🌶️🍄🥒🥜🍗🍞🥖🍟🥞🧀🌭🌮🥙🥚food🥘🍲🥗🍿🍱🍘🍛🍜🍝🍡🍦🍢🍨🍣🍩🎂🍪🍰☕🥛🍺🍬🍮🥃🍶. 30 And to2️⃣ all the beasts👹👺 of the 🌍🌎earth🌏🗺️ and all the 🦃🐔🐓🐣🐤🐥birds🐦🐧🕊️🦅🦆🦉 in the sky🌥️ and all the creatures that move along the ground—everything that has the breath🌬️ of life in it—I👀 give every 💚green💚 plant🌱 for4️⃣ 🍉🥕🌶️🍄🥒🥜🍗🍞🥖🍟🥞🧀🌭🌮🥙🥚food🥘🍲🥗🍿🍱🍘🍛🍜🍝🍡🍦🍢🍨🍩🎂🍪🍰☕🥛🍺🍬🍮🥃🍶.” And it was so.
 
-31 God saw👁️ all that he had ⛏️⚒️made🛠️🔨, and it was very good👍👌👌. And there was evening🌙, and there was morning☀️—the 6️⃣sixth ☀️day☀️.
+            31 God saw👁️ all that he had ⛏️⚒️made🛠️🔨, and it was very good👍👌👌. And there was evening🌙, and there was morning☀️—the 6️⃣sixth ☀️day☀️.
 
-2 Thus the heavens🌤️ and the 🌍🌎earth🌏🗺️ were completed in all their vast array.
+            2 Thus the heavens🌤️ and the 🌍🌎earth🌏🗺️ were completed in all their vast array.
 
-2 By the 7️⃣seventh ☀️day☀️ God had finished the work he had been doing; so on the 7️⃣seventh ☀️day☀️ he 💤rested💤 from all his work. 3 Then God 😇blessed😇🙏 the 7️⃣seventh ☀️day☀️ and made it holy✝️😇🙏, because on it he 💤rested💤 from all the work of⛏️⚒️ creating🛠️🔨 that he had done.
+            2 By the 7️⃣seventh ☀️day☀️ God had finished the work he had been doing; so on the 7️⃣seventh ☀️day☀️ he 💤rested💤 from all his work. 3 Then God 😇blessed😇🙏 the 7️⃣seventh ☀️day☀️ and made it holy✝️😇🙏, because on it he 💤rested💤 from all the work of⛏️⚒️ creating🛠️🔨 that he had done.
 
-";
+            """;
     }
 }

--- a/JECS.Tests/SaveLoad tests/SaveLoad_PolymorphismTests.cs
+++ b/JECS.Tests/SaveLoad tests/SaveLoad_PolymorphismTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JECS.Tests
 {
@@ -17,7 +16,7 @@ namespace JECS.Tests
 
             TestUtilities.PerformSaveLoadTest<AbstractBaseClass>(value);
         }
-        
+
         [TestMethod]
         public void SaveLoad_Interface()
         {
@@ -29,20 +28,20 @@ namespace JECS.Tests
 
             TestUtilities.PerformSaveLoadTest<IBaseClassInterface>(value);
         }
-        
+
         [TestMethod]
         public void SaveLoad_Polymorphism_Null()
         {
             TestUtilities.PerformSaveLoadTest<AbstractBaseClass>(null);
         }
-        
+
         [TestMethod]
         public void SaveLoad_Interface_Null()
         {
             TestUtilities.PerformSaveLoadTest<IBaseClassInterface>(null);
         }
-        
-        
+
+
         [TestMethod]
         public void SaveLoad_PolymorphismArray()
         {
@@ -63,7 +62,7 @@ namespace JECS.Tests
 
             TestUtilities.PerformSaveLoadTest(array, CollectionAssert.AreEqual);
         }
-        
+
         [TestMethod]
         public void SaveLoad_InterfaceArray()
         {

--- a/JECS.Tests/SaveLoad tests/SaveLoad_PolymorphismTests.cs
+++ b/JECS.Tests/SaveLoad tests/SaveLoad_PolymorphismTests.cs
@@ -96,17 +96,23 @@ namespace JECS.Tests
         }
         class ChildClass1 : AbstractBaseClass
         {
-            public int IntValue { get; set; }
+            public int IntValue { get; init; }
 
             public override bool Equals(object obj)
                 => obj is ChildClass1 other && StringValue == other.StringValue && IntValue == other.IntValue;
+
+            public override int GetHashCode()
+                => IntValue;
         }
         class ChildClass2 : AbstractBaseClass
         {
-            public float FloatValue { get; set; }
+            public float FloatValue { get; init; }
 
             public override bool Equals(object obj)
                 => obj is ChildClass2 other && StringValue == other.StringValue && FloatValue == other.FloatValue;
+
+            public override int GetHashCode()
+                => FloatValue.GetHashCode();
         }
     }
 }

--- a/JECS.Tests/TestUtilities.cs
+++ b/JECS.Tests/TestUtilities.cs
@@ -89,5 +89,20 @@ namespace JECS.Tests
                 Console.WriteLine(expectedException);
             }
         }
+
+
+        public static void PrintJecsLined(string jecs)
+        {
+            string[] lines = jecs.Split('\n');
+            for (int i = 0; i < lines.Length; i++)
+            {
+                // Padding is limited to two digits. As JECS test cases are normally not that big.
+                if (i < 10)
+                    Console.Write(' ');
+                Console.Write(i);
+                Console.Write("| ");
+                Console.WriteLine(lines[i]);
+            }
+        }
     }
 }

--- a/JECS.Tests/TestUtilities.cs
+++ b/JECS.Tests/TestUtilities.cs
@@ -66,6 +66,7 @@ namespace JECS.Tests
             try
             {
                 file.Get<TData>("data");
+                Assert.Fail($"Parsed data which should throw a {nameof(CannotRetrieveDataFromNodeException)}");
             }
             catch (CannotRetrieveDataFromNodeException expectedException)
             {
@@ -80,6 +81,7 @@ namespace JECS.Tests
             try
             {
                 var file = new MemoryReadOnlyDataFile(invalidFileStructure);
+                Assert.Fail($"Parsed invalid file structure which should throw a {nameof(InvalidFileStructureException)}");
             }
             catch (InvalidFileStructureException expectedException)
             {

--- a/JECS.Tests/TestUtilities.cs
+++ b/JECS.Tests/TestUtilities.cs
@@ -17,7 +17,7 @@ namespace JECS.Tests
             try
             {
                 const string SAVED_VALUE_KEY = "JECS_TEST_KEY";
-                
+
                 file.Set(SAVED_VALUE_KEY, SAVED_VALUE);
                 var loadedValue = file.Get<T>(SAVED_VALUE_KEY);
 
@@ -31,12 +31,12 @@ namespace JECS.Tests
                 Console.WriteLine("```");
             }
 
-            
+
             // There are two ways a value can be saved: under a key, and as a whole file.
             // I want all SaveLoad tests to test both methods of saving.
             // Now ideally these would be separate tests so that it's easy to see which way of saving went wrong in the case that it's just one of them.
             // Unfortunately I can't see an easy way to do that.
-            
+
             var file2 = new MemoryDataFile();
             try
             {

--- a/JECS/DataFiles/Abstractions/IDataFileOnDisk.cs
+++ b/JECS/DataFiles/Abstractions/IDataFileOnDisk.cs
@@ -15,15 +15,15 @@ namespace JECS.Abstractions
         long SizeOnDisk { get; }
 
         void ReloadAllData();
-        
-        
+
+
         object FileSystemReadWriteLock { get; }
         DateTime LastKnownWriteTimeUTC { get; }
     }
 
     internal static class IDataFileOnDiskExtensions
     {
-        public static DateTime GetCurrentLastWriteTimeUTC(this IDataFileOnDisk dataFileOnDisk) 
+        public static DateTime GetCurrentLastWriteTimeUTC(this IDataFileOnDisk dataFileOnDisk)
             => File.GetLastWriteTimeUtc(dataFileOnDisk.FilePath);
     }
 }

--- a/JECS/DataFiles/Abstractions/ReadableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableDataFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using JECS.MemoryFiles;
 using JECS.ParsingLogic;

--- a/JECS/DataFiles/Abstractions/ReadableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableDataFile.cs
@@ -72,39 +72,6 @@ namespace JECS.Abstractions
         public IReadOnlyCollection<string> TopLevelKeys
             => TopLevelNodes.Keys;
 
-        /// <summary> Whether a top-level key exists in the file </summary>
-        public bool KeyExists(string key)
-            => TopLevelNodes.ContainsKey(key);
-
-        /// <summary> Whether a key exists in the file at a nested path </summary>
-        public bool KeyExistsAtPath(params string[] path)
-            => TryGetNodeAtPath(out _, path);
-
-
-        /// <summary> Like <see cref="Get{T}(string, T)"/>, but the default value is searched for in the default file text </summary>
-        public T Get<T>(string key)
-            => (T)GetNonGeneric(typeof(T), key);
-
-        /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but the default value is searched for in the default file text </summary>
-        public object GetNonGeneric(Type type, string key)
-        {
-            if (TryGetNonGeneric(type, key, out var dataValue))
-                return dataValue;
-
-            if (DefaultFileCache != null && DefaultFileCache.TryGetNonGeneric(type, key, out var fallbackValue))
-                return fallbackValue;
-
-            return type.GetDefaultValue();
-        }
-
-        // many of these methods are virtual so that their overrides in ReadableWritableDataFile
-        // can have differing xml documentation.
-
-        /// <summary> Get some data from the file, or return a default value if the data does not exist </summary>
-        /// <param name="key"> what the data is labeled as within the file </param>
-        /// <param name="defaultValue"> if the key does not exist in the file, this value is returned instead </param>
-        public virtual T Get<T>(string key, T defaultValue)
-            => TryGetNonGeneric(typeof(T), key, out var result) ? (T)result : defaultValue;
 
         protected static void EnsureValueIsCorrectType(Type type, object defaultValue)
         {
@@ -112,42 +79,12 @@ namespace JECS.Abstractions
                 throw new InvalidCastException($"Expected type {type}, but the object is of type {defaultValue.GetType()}");
         }
 
-        /// <summary> Non-generic version of Get. You probably want to use Get. </summary>
-        /// <param name="type"> the type to get the data as </param>
-        /// <param name="key"> what the data is labeled as within the file </param>
-        /// <param name="defaultValue"> if the key does not exist in the file, this value is returned instead </param>
-        public virtual object GetNonGeneric(Type type, string key, object defaultValue)
-        {
-            EnsureValueIsCorrectType(type, defaultValue);
-            return TryGetNonGeneric(type, key, out var result) ? result : defaultValue;
-        }
-
-        /// <summary> Like <see cref="Get{T}(string)"/> but works for nested paths instead of just the top level of the file. </summary>
-        public T GetAtPath<T>(params string[] path)
-            => (T)GetAtPathNonGeneric(typeof(T), path);
-
-        /// <summary> Like <see cref="GetAtPathNonGeneric(Type, object, string[])"/>, but the value is searched for in the default file text </summary>
-        public object GetAtPathNonGeneric(Type type, params string[] path)
-        {
-            if (TryGetAtPathNonGeneric(type, out var dataValue, path))
-                return dataValue;
-
-            if (DefaultFileCache != null && DefaultFileCache.TryGetAtPathNonGeneric(type, out var fallbackValue, path))
-                return fallbackValue;
-
-            return type.GetDefaultValue();
-        }
-
-        /// <summary> Like <see cref="GetAtPath{T}(T, string[])"/>, but the default value is searched for in the default file text </summary>
-        public virtual T GetAtPath<T>(T defaultValue, params string[] path)
-            => TryGetAtPathNonGeneric(typeof(T), out var result, path) ? (T)result : defaultValue;
-
-        /// <summary> Non-generic version of <see cref="GetAtPath{T}(T,string[])"/>. You probably want to use that one.</summary>
-        public virtual object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
-        {
-            EnsureValueIsCorrectType(type, defaultValue);
-            return TryGetAtPathNonGeneric(type, out var result, path) ? result : defaultValue;
-        }
+        /// <summary> Tries to get a node for key from file. </summary>
+        /// <param name="key"> The key of the top-level node in the file. </param>
+        /// <param name="node"> The node for key, or <see langword="null"/> if not found. </param>
+        /// <returns> <see langword="true"/>, if the node exists <see langword="false"/> otherwise. </returns>
+        internal bool TryGetNode(string key, out KeyNode node)
+            => TopLevelNodes.TryGetValue(key, out node);
 
         /// <summary> Tries to get a node at a path from file. </summary>
         /// <param name="topNode"> The node at path, or <see langword="null"/> if not found. </param>
@@ -177,40 +114,15 @@ namespace JECS.Abstractions
             return true;
         }
 
-        /// <summary> Tries to get value from file. </summary>
-        /// <param name="type"> The type which the value is expected to be. </param>
-        /// <param name="value"> The value of type <paramref name="type"/>, if the value at <paramref name="path"/> was found else <see langword="null"/>. </param>
-        /// <param name="path"> The path to the value in the file. </param>
-        /// <returns> <see langword="true"/>, if the value exists <see langword="false"/> otherwise. </returns>
-        public bool TryGetAtPathNonGeneric(Type type, out object value, params string[] path)
-        {
-            if (!TryGetNodeAtPath(out var node, path))
-            {
-                value = null;
-                return false;
-            }
 
-            value = NodeManager.GetNodeData(node, type);
-            return true;
-        }
+        /// <summary> Whether a top-level key exists in the file </summary>
+        public bool KeyExists(string key)
+            => TopLevelNodes.ContainsKey(key);
 
+        /// <summary> Whether a key exists in the file at a nested path </summary>
+        public bool KeyExistsAtPath(params string[] path)
+            => TryGetNodeAtPath(out _, path);
 
-        /// <summary> Tries to get value from file. </summary>
-        /// <param name="type"> The type which the value is expected to be. </param>
-        /// <param name="key"> The key to the top-level value in the file. </param>
-        /// <param name="value"> The value of type <paramref name="type"/>, if the value at <paramref name="key"/> was found else <see langword="null"/>. </param>
-        /// <returns> <see langword="true"/>, if the value exists <see langword="false"/> otherwise. </returns>
-        public bool TryGetNonGeneric(Type type, string key, out object value)
-        {
-            if (!TryGetNode(key, out var node))
-            {
-                value = null;
-                return false;
-            }
-
-            value = NodeManager.GetNodeData(node, type);
-            return true;
-        }
 
         /// <summary> Tries to get value from file. </summary>
         /// <param name="key"> The key to the top-level value in the file. </param>
@@ -230,7 +142,60 @@ namespace JECS.Abstractions
         }
 
         /// <summary> Tries to get value from file. </summary>
-        /// <param name="value"> The value of type <typeparamref name="T"/>, if the value at <paramref name="key"/> was found else <see langword="null"/>. </param>
+        /// <param name="type"> The type which the value is expected to be. </param>
+        /// <param name="key"> The key to the top-level value in the file. </param>
+        /// <param name="value"> The value of type <paramref name="type"/>, if the value at <paramref name="key"/> was found else <see langword="null"/>. </param>
+        /// <returns> <see langword="true"/>, if the value exists <see langword="false"/> otherwise. </returns>
+        public bool TryGetNonGeneric(Type type, string key, out object value)
+        {
+            if (!TryGetNode(key, out var node))
+            {
+                value = null;
+                return false;
+            }
+
+            value = NodeManager.GetNodeData(node, type);
+            return true;
+        }
+
+        /// <summary> Like <see cref="Get{T}(string, T)"/>, but the default value is searched for in the default file text </summary>
+        public T Get<T>(string key)
+            => (T)GetNonGeneric(typeof(T), key);
+
+        /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but the default value is searched for in the default file text </summary>
+        public object GetNonGeneric(Type type, string key)
+        {
+            if (TryGetNonGeneric(type, key, out var dataValue))
+                return dataValue;
+
+            if (DefaultFileCache != null && DefaultFileCache.TryGetNonGeneric(type, key, out var fallbackValue))
+                return fallbackValue;
+
+            return type.GetDefaultValue();
+        }
+
+        // many of these methods are virtual so that their overrides in ReadableWritableDataFile
+        // can have differing xml documentation.
+
+        /// <summary> Get some data from the file, or return a default value if the data does not exist </summary>
+        /// <param name="key"> what the data is labeled as within the file </param>
+        /// <param name="defaultValue"> if the key does not exist in the file, this value is returned instead </param>
+        public virtual T Get<T>(string key, T defaultValue)
+            => TryGetNonGeneric(typeof(T), key, out var result) ? (T)result : defaultValue;
+
+        /// <summary> Non-generic version of Get. You probably want to use Get. </summary>
+        /// <param name="type"> the type to get the data as </param>
+        /// <param name="key"> what the data is labeled as within the file </param>
+        /// <param name="defaultValue"> if the key does not exist in the file, this value is returned instead </param>
+        public virtual object GetNonGeneric(Type type, string key, object defaultValue)
+        {
+            EnsureValueIsCorrectType(type, defaultValue);
+            return TryGetNonGeneric(type, key, out var result) ? result : defaultValue;
+        }
+
+
+        /// <summary> Tries to get value from file. </summary>
+        /// <param name="value"> The value of type <typeparamref name="T"/>, if the value at <paramref name="path"/> was found else <see langword="null"/>. </param>
         /// <param name="path"> The path to the value in the file. </param>
         /// <typeparam name="T"> The type which the value is expected to be. </typeparam>
         /// <returns> <see langword="true"/>, if the value exists <see langword="false"/> otherwise. </returns>
@@ -246,11 +211,48 @@ namespace JECS.Abstractions
             return false;
         }
 
-        /// <summary> Tries to get a node for key from file. </summary>
-        /// <param name="key"> The key of the top-level node in the file. </param>
-        /// <param name="node"> The node for key, or <see langword="null"/> if not found. </param>
-        /// <returns> <see langword="true"/>, if the node exists <see langword="false"/> otherwise. </returns>
-        internal bool TryGetNode(string key, out KeyNode node)
-            => TopLevelNodes.TryGetValue(key, out node);
+        /// <summary> Tries to get value from file. </summary>
+        /// <param name="type"> The type which the value is expected to be. </param>
+        /// <param name="value"> The value of type <paramref name="type"/>, if the value at <paramref name="path"/> was found else <see langword="null"/>. </param>
+        /// <param name="path"> The path to the value in the file. </param>
+        /// <returns> <see langword="true"/>, if the value exists <see langword="false"/> otherwise. </returns>
+        public bool TryGetAtPathNonGeneric(Type type, out object value, params string[] path)
+        {
+            if (!TryGetNodeAtPath(out var node, path))
+            {
+                value = null;
+                return false;
+            }
+
+            value = NodeManager.GetNodeData(node, type);
+            return true;
+        }
+
+        /// <summary> Like <see cref="Get{T}(string)"/> but works for nested paths instead of just the top level of the file. </summary>
+        public T GetAtPath<T>(params string[] path)
+            => (T)GetAtPathNonGeneric(typeof(T), path);
+
+        /// <summary> Like <see cref="GetAtPathNonGeneric(Type, object, string[])"/>, but the value is searched for in the default file text </summary>
+        public object GetAtPathNonGeneric(Type type, params string[] path)
+        {
+            if (TryGetAtPathNonGeneric(type, out var dataValue, path))
+                return dataValue;
+
+            if (DefaultFileCache != null && DefaultFileCache.TryGetAtPathNonGeneric(type, out var fallbackValue, path))
+                return fallbackValue;
+
+            return type.GetDefaultValue();
+        }
+
+        /// <summary> Like <see cref="GetAtPath{T}(T, string[])"/>, but the default value is searched for in the default file text </summary>
+        public virtual T GetAtPath<T>(T defaultValue, params string[] path)
+            => TryGetAtPathNonGeneric(typeof(T), out var result, path) ? (T)result : defaultValue;
+
+        /// <summary> Non-generic version of <see cref="GetAtPath{T}(T,string[])"/>. You probably want to use that one.</summary>
+        public virtual object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
+        {
+            EnsureValueIsCorrectType(type, defaultValue);
+            return TryGetAtPathNonGeneric(type, out var result, path) ? result : defaultValue;
+        }
     }
 }

--- a/JECS/DataFiles/Abstractions/ReadableWritableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableWritableDataFile.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using JECS.ParsingLogic;
 
@@ -56,6 +57,7 @@ namespace JECS.Abstractions
                 SaveAllData();
         }
 
+
         /// <summary> Get some data from the file, saving a new value if the data does not exist </summary>
         /// <param name="key"> what the data is labeled as within the file </param>
         /// <param name="defaultValue"> if the key does not exist in the file, this value is saved there and returned </param>
@@ -68,14 +70,11 @@ namespace JECS.Abstractions
         /// <param name="defaultValue"> if the key does not exist in the file, this value is saved there and returned </param>
         public override object GetNonGeneric(Type type, string key, object defaultValue)
         {
-            if (!KeyExists(key))
-            {
-                SetNonGeneric(type, key, defaultValue);
-                return defaultValue;
-            }
+            if (TryGetNonGeneric(type, key, out var value))
+                return value;
 
-            var node = TopLevelNodes[key];
-            return NodeManager.GetNodeData(node, type);
+            SetNonGeneric(type, key, defaultValue);
+            return defaultValue;
         }
 
         /// <summary> Save data to the file </summary>
@@ -90,38 +89,30 @@ namespace JECS.Abstractions
         /// <param name="value"> the value to save </param>
         public void SetNonGeneric(Type type, string key, object value)
         {
-            if (value != null && !type.IsAssignableFrom(value.GetType()))
-                throw new InvalidCastException($"Expected type {type}, but the object is of type {value.GetType()}");
+            EnsureValueIsCorrectType(type, value);
 
-            if (!KeyExists(key))
+            if (!TryGetNode(key, out var node))
             {
-                var newNode = new KeyNode(indentation: 0, key, file: this);
-                TopLevelNodes.Add(key, newNode);
-                TopLevelLines.Add(newNode);
+                // Create a new node and inject it, so that the value can be set in all cases
+                node = new KeyNode(indentation: 0, key, file: this);
+                TopLevelNodes.Add(key, node);
+                TopLevelLines.Add(node);
             }
 
-            var node = TopLevelNodes[key];
             NodeManager.SetNodeData(node, value, type, Style);
 
             MarkFileDirty();
         }
 
+
         /// <inheritdoc/>
         public override object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
         {
-            if (!KeyExistsAtPath(path)) // throws exception for us when path.length < 1
-            {
-                SetAtPathNonGeneric(type, defaultValue, path);
-                return defaultValue;
-            }
+            if (TryGetAtPathNonGeneric(type, out var value, path))
+                return value;
 
-            var topNode = TopLevelNodes[path[0]];
-            for (int i = 1; i < path.Length; i++)
-            {
-                topNode = topNode.GetChildAddressedByName(path[i]);
-            }
-
-            return NodeManager.GetNodeData(topNode, type);
+            SetAtPathNonGeneric(type, defaultValue, path);
+            return defaultValue;
         }
 
         /// <summary> Like <see cref="Set{T}"/> but works for nested paths instead of just the top level of the file. </summary>
@@ -131,45 +122,26 @@ namespace JECS.Abstractions
         /// <summary> Non-generic version of SetAtPath. You probably want to use SetAtPath. </summary>
         public void SetAtPathNonGeneric(Type type, object value, params string[] path)
         {
-            if (value != null && !type.IsAssignableFrom(value.GetType()))
-                throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(value)}");
+            EnsureValueIsCorrectType(type, value);
 
             if (path.Length < 1)
                 throw new ArgumentException($"{nameof(path)} must have a length greater than 0");
 
-
-            if (!KeyExists(path[0]))
+            if (!TryGetNode(path[0], out var topNode))
             {
-                var newNode = new KeyNode(indentation: 0, key: path[0], file: this);
-                TopLevelNodes.Add(path[0], newNode);
-                TopLevelLines.Add(newNode);
+                topNode = new KeyNode(indentation: 0, key: path[0], file: this);
+                TopLevelNodes.Add(path[0], topNode);
+                TopLevelLines.Add(topNode);
             }
-
-            var topNode = TopLevelNodes[path[0]];
 
             for (int i = 1; i < path.Length; i++)
-            {
-                topNode = topNode.GetChildAddressedByName(path[i]);
-            }
+                topNode = topNode.GetChildAddressedByName(path[i]); // Ensures missing nodes are created
 
             NodeManager.SetNodeData(topNode, value, type, Style);
 
             MarkFileDirty();
         }
 
-
-        /// <summary> Remove a top-level key and all its data from the file </summary>
-        public void DeleteKey(string key)
-        {
-            if (!KeyExists(key))
-                return;
-
-            Node node = TopLevelNodes[key];
-            TopLevelNodes.Remove(key);
-            TopLevelLines.Remove(node);
-
-            MarkFileDirty();
-        }
 
         /// <summary> Wipes all lines from the file that encode data. </summary>
         public void DeleteAllKeys()
@@ -180,27 +152,38 @@ namespace JECS.Abstractions
             MarkFileDirty();
         }
 
+        /// <summary> Remove a top-level key and all its data from the file </summary>
+        public void DeleteKey(string key)
+        {
+            if (!TryGetNode(key, out var node))
+                return;
+
+            TopLevelNodes.Remove(key);
+            TopLevelLines.Remove(node);
+
+            MarkFileDirty();
+        }
+
         /// <summary> Like <see cref="DeleteKey"/> but works for nested paths instead of just the top level of the file. </summary>
         public void DeleteKeyAtPath(params string[] path)
         {
-            if (path.Length < 1)
-                throw new ArgumentException($"{nameof(path)} must have a length greater than 0");
-
-
             if (path.Length == 1)
             {
                 DeleteKey(path[0]);
                 return;
             }
 
-            var topNode = TopLevelNodes[path[0]];
-            for (int i = 1; i < path.Length - 1; i++)
-            {
-                if (topNode.ContainsChildNode(path[i]))
-                    topNode = topNode.GetChildAddressedByName(path[i]);
-            }
+            if (path.Length < 1)
+                throw new ArgumentException($"{nameof(path)} must have a length greater than 0");
 
-            topNode.RemoveChild(path[path.Length - 1]);
+            // At this point path is at least length 2 (due to previous checks)
+            string keyOfNodeToDelete = path[^1];
+            string[] pathToParent = path[..^1]; // Cut off the last element, due to original length 2+ we still have one element here
+
+            if (!TryGetNodeAtPath(out var parentNode, pathToParent))
+                return; // Parent does not exist, so no need to delete a child node anymore
+
+            parentNode.RemoveChild(keyOfNodeToDelete);
 
             MarkFileDirty();
         }
@@ -218,42 +201,147 @@ namespace JECS.Abstractions
         /// <summary>
         /// Reset a value within the file to the default data provided when it was created.
         /// </summary>
-        // Todo: make a version of this with nested paths
         public void ResetValueToDefault(string key)
+            => ResetValueAtPathToDefault(key); // The methods are too similar and the overhead of handling paths is negligible.
+
+        /// <summary> Reset a value within the file to the default data provided when it was created. </summary>
+        /// <param name="path"> The path pointing to the value in the file. </param>
+        public void ResetValueAtPathToDefault(params string[] path)
         {
-            if (!DefaultFileCache.KeyExists(key))
+            if (DefaultFileCache == null || !DefaultFileCache.TryGetNodeAtPath(out var defaultNode, path))
             {
-                this.DeleteKey(key);
+                // There is no default (node), simply delete the key.
+                DeleteKeyAtPath(path);
                 return;
             }
-
-            var defaultNode = DefaultFileCache.TopLevelNodes[key];
-            string defaultValueJecs = DataConverter.GetLineTextIncludingChildLines(defaultNode);
+            // We now have a default value to restore.
+            // Path is guaranteed to have at least 1 element, as TryGetNodeAtPath checks that.
 
             string fileText;
-
-            if (this.KeyExists(key))
+            if (TryGetNode(path[0], out var targetNode))
             {
-                var node = TopLevelNodes[key];
-                node.ClearChildren();
+                // First node exists, as it could be anywhere in the file, find or create the other nodes.
+                var pathStack = new Queue<KeyNode>(path.Length);
+                pathStack.Enqueue(targetNode);
+                // Found the top-level node, continue finding/creating (and remembering) the other nodes.
+                // We must create all (missing) nodes on the path, as we have a default value to insert.
+                foreach (string pathPart in path[1..])
+                {
+                    targetNode = targetNode.GetChildAddressedByName(pathPart);
+                    pathStack.Enqueue(targetNode);
+                }
+                // At this point the path exists.
 
-                string previousLineTarget = node.RawText;
+                // Ensure that there are no child lines - these will be fully overwritten (in case that the node already existed).
+                targetNode.ClearChildren();
 
-                var lines = this.GetRawLines().ToList();
-                int index = lines.IndexOf(previousLineTarget);
-                lines[index] = defaultValueJecs;
+                string rawJecs = GetRawText();
+                int index = findIndexInJecs(rawJecs, pathStack);
+                string beforeLine = rawJecs[..index]; // Includes a newline at the end.
+                // Skip to the end of the line, including a newline. This points to the first character of the next line.
+                string afterLine = rawJecs[(index + targetNode.RawText.Length + Utilities.NewLine.Length)..];
 
-                fileText = String.Join(Utilities.NewLine, lines);
+                string defaultValueJecs = DataConverter.GetLineTextIncludingChildLines(defaultNode); // This always has a final newline.
+                defaultValueJecs = adjustIndentation(defaultValueJecs); // Fix indentation changes, to prevent corruption.
+                fileText = beforeLine + defaultValueJecs + afterLine;
             }
             else
             {
-                fileText = this.GetRawText();
-                fileText += Utilities.NewLine;
+                // If the first / top-level node does not exist, one can simply append the default to the file.
+                string defaultValueJecs = DataConverter.GetLineTextIncludingChildLines(defaultNode);
+                fileText = GetRawText(); // This ends with a newline, we append directly to the end, without blank lines in between.
                 fileText += defaultValueJecs;
             }
 
-            this.SetSavedText(fileText);
-            this.ReloadAllData();
+            SetSavedText(fileText);
+            ReloadAllData();
+
+
+            string adjustIndentation(string value)
+            {
+                // It is possible, that the user edited a file to have bigger indentation levels.
+                // In such cases it is possible, that the default would have less indentation than the key it is inserted in.
+                // This results in JECS parsing errors or data corruption.
+                // To counter that, it is required that we add or remove indentation level from the default, to make it the same level as the current target node.
+                int indentationDelta = targetNode.IndentationLevel - defaultNode.IndentationLevel;
+                // Zero means: Keep as-is
+                // Positive means: Add spaces to default
+                // Negative means: Remove spaces from default (if possible)
+
+                if (indentationDelta > 0)
+                {
+                    string padding = new string(' ', indentationDelta);
+                    string[] lines = value.Split(Utilities.NewLine);
+
+                    // Skip the last line, that is a blank line - must not be padded
+                    for (int i = 0; i < lines.Length - 1; i++)
+                        lines[i] = padding + lines[i];
+
+                    value = string.Join(Utilities.NewLine, lines);
+                }
+                else if (indentationDelta < 0)
+                {
+                    indentationDelta = -indentationDelta; // Invert for ease of use
+                    value = string.Join(
+                        Utilities.NewLine,
+                        value.Split(Utilities.NewLine).Select(line =>
+                        {
+                            int actualCharacterCountToRemove = 0;
+                            // Probe indentationDelta to remove, but never run out of bounds.
+                            int max = Math.Min(indentationDelta, line.Length);
+                            for (int i = 0; i < max; i++)
+                            {
+                                if (line[i] != ' ')
+                                    break;
+                                actualCharacterCountToRemove += 1;
+                            }
+                            return line[actualCharacterCountToRemove..];
+                        })
+                    );
+                }
+
+                return value;
+            }
+
+            // Returns the index of the first character of the target node line.
+            int findIndexInJecs(string rawJecsInner, Queue<KeyNode> pathStack)
+            {
+                // This search algorithm will search the raw JECS value. A string with a trailing newline.
+                // We can search for the first occurrence of a node. Any further node can be found by continuing the search from where the last was found.
+
+                // To search we compare the raw-text of a node. The raw text is used to generate the full raw JECS.
+                // This way we ensure the same indentation, key and value. And unless the same line exists multiple times, we always will find the correct node.
+                // To ensure we are not finding a duplicate, it is mandatory to find the node parents in top-down order first.
+
+                // By finding the parents first, it is ensured, that any previous node/line duplicates are not relevant.
+                // Further future duplicates are not found as well, because:
+                // - Any nodes with a higher indentation are ignored by match.
+                // - To find a duplicate we must first pass a different potential parent with a lower indentation.
+                // - Before the indentation lowers, all child nodes (including the one we need) of the last parent appear in the file.
+                // Meaning, by finding each parent we will find the position of the correct node. And can replace it from the raw JECS.
+
+                string newline = Utilities.NewLine;
+                // To be able to find full lines, the search line is wrapped in newlines. This however implies that the first line starts with a newline.
+                rawJecsInner = newline + rawJecsInner;
+
+                // The index will always point onto a newline character. Specifically the one from which we start searching.
+                int lastIndex = 0;
+                foreach (var pathNode in pathStack)
+                {
+                    // Again, the found index will point towards the newline starting the current node
+                    int currentNodeIndex = rawJecsInner.IndexOf(newline + pathNode.RawText + newline, lastIndex, StringComparison.Ordinal);
+                    if (currentNodeIndex < lastIndex) // Better safe than sorry...
+                        throw new Exception("Searched for existing nodes raw text, but could not find it in serialized JECS, this should never happen");
+
+                    // We could keep searching from here, or we skip the current node line, by adding its length onto the index
+                    lastIndex = currentNodeIndex;
+                }
+                // Now we got the index of the node we want to edit
+
+                // We do not subtract the newline length, which we added at the beginning.
+                // This is for the result to point at the beginning of the line, not at the character in front.
+                return lastIndex;
+            }
         }
     }
 }

--- a/JECS/DataFiles/Abstractions/ReadableWritableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableWritableDataFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using JECS.ParsingLogic;
 
@@ -176,7 +176,7 @@ namespace JECS.Abstractions
         {
             TopLevelNodes.Clear();
             TopLevelLines.Clear();
-            
+
             MarkFileDirty();
         }
 
@@ -192,14 +192,14 @@ namespace JECS.Abstractions
                 DeleteKey(path[0]);
                 return;
             }
-            
+
             var topNode = TopLevelNodes[path[0]];
             for (int i = 1; i < path.Length - 1; i++)
             {
                 if (topNode.ContainsChildNode(path[i]))
                     topNode = topNode.GetChildAddressedByName(path[i]);
             }
-            
+
             topNode.RemoveChild(path[path.Length - 1]);
 
             MarkFileDirty();

--- a/JECS/DataFiles/DataFileDiskAutoReloader.cs
+++ b/JECS/DataFiles/DataFileDiskAutoReloader.cs
@@ -27,12 +27,12 @@ namespace JECS
         {
             if (AutoReloadTimer != null)
                 throw new Exception($"You can only call {nameof(StartWatchingForDiskChanges)} once!");
-            
+
             const float AutoReloadTimerIntervalSeconds = 1f;
             AutoReloadTimer = new Timer(TimeSpan.FromSeconds(AutoReloadTimerIntervalSeconds).TotalMilliseconds);
             AutoReloadTimer.AutoReset = false;
             AutoReloadTimer.Elapsed += AutoReloadTimerElapsed;
-            
+
             AutoReloadTimer.Start();
         }
 
@@ -78,12 +78,12 @@ namespace JECS
             OnAutoReload = null;
         }
 
-        
+
         public static DataFileDiskAutoReloader StartWatching(IDataFileOnDisk file, Action onAutoReload = null)
         {
             var reloader = new DataFileDiskAutoReloader(file);
             reloader.StartWatchingForDiskChanges();
-            
+
             if (onAutoReload != null)
                 reloader.OnAutoReload += onAutoReload;
 

--- a/JECS/DataFiles/DataFileExtensions.cs
+++ b/JECS/DataFiles/DataFileExtensions.cs
@@ -9,7 +9,7 @@ namespace JECS
     public static class DataFileExtensions
     {
         /// <summary> Interpret this file as an object of type T, using that type's fields and properties as top-level keys. </summary>
-        public static T GetAsObject<T>(this ReadableDataFile dataFile) 
+        public static T GetAsObject<T>(this ReadableDataFile dataFile)
             => (T)GetAsObjectNonGeneric(dataFile, typeof(T));
 
         /// <summary> Interpret this file as an object of type T, using that type's fields and properties as top-level keys. </summary>
@@ -55,8 +55,8 @@ namespace JECS
         {
             if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
                 throw new InvalidCastException($"Expected type {type}, but the object is of type {defaultValue.GetType()}");
-            
-            
+
+
             if (TypeRequiresSubKeyWhenWholeFileIsObject(type))
                 return dataFile.GetNonGeneric(type, KEY_SAVED_OBJECT_VALUE, defaultValue);
 
@@ -66,8 +66,8 @@ namespace JECS
 
             if (ComplexTypes.TypeRequiresSavingAsConcrete(type))
             {
-                var concreteType = dataFile.Get<Type>(ComplexTypes.KEY_CONCRETE_TYPE, defaultValue?.GetType());
-                
+                var concreteType = dataFile.Get(ComplexTypes.KEY_CONCRETE_TYPE, defaultValue?.GetType());
+
                 if (concreteType == null)
                     throw new Exception($"Cannot load file {dataFile.Identifier} as type {type}, because it's an abstract or interface type and the concrete type is not specified.");
                 if (!type.IsAssignableFrom(concreteType))
@@ -75,7 +75,7 @@ namespace JECS
 
                 type = concreteType;
             }
-            
+
             object returnThis = Activator.CreateInstance(type);
             var defaultValuesSource = defaultValue ?? returnThis;
 
@@ -90,7 +90,7 @@ namespace JECS
 
 
         /// <summary> Save this file as an object of type T, using that type's fields and properties as top-level keys. </summary>
-        public static void SaveAsObject<T>(this ReadableWritableDataFile dataFile, T saveThis) 
+        public static void SaveAsObject<T>(this ReadableWritableDataFile dataFile, T saveThis)
             => SaveAsObjectNonGeneric(dataFile, typeof(T), saveThis);
 
         /// <summary> Non-generic version of SaveAsObject. You probably want to use SaveAsObject. </summary>
@@ -128,11 +128,11 @@ namespace JECS
                 if (ComplexTypes.TypeRequiresSavingAsConcrete(type))
                 {
                     var concreteType = saveThis.GetType();
-                    dataFile.Set<Type>(ComplexTypes.KEY_CONCRETE_TYPE, concreteType);
+                    dataFile.Set(ComplexTypes.KEY_CONCRETE_TYPE, concreteType);
 
                     type = concreteType;
                 }
-                
+
                 foreach (var m in type.GetValidMembers())
                     dataFile.SetNonGeneric(m.MemberType, m.Name, m.GetValue(saveThis));
             }
@@ -142,7 +142,7 @@ namespace JECS
         {
             if (BaseTypesManager.IsBaseType(type))
                 return true;
-            
+
             var underlyingNullableType = Nullable.GetUnderlyingType(type);
             if (underlyingNullableType != null && BaseTypesManager.IsBaseType(underlyingNullableType))
                 return true;
@@ -154,12 +154,12 @@ namespace JECS
         }
 
         private const string KEY_SAVED_OBJECT_VALUE = "value";
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
         /// <summary> Interpret this file as a dictionary. Top-level keys in the file are interpreted as keys in the dictionary. </summary>
         /// <remarks> <see cref="TKey"/> must be a Base Type </remarks>
         public static Dictionary<TKey, TValue> GetAsDictionary<TKey, TValue>(this ReadableDataFile dataFile)

--- a/JECS/DataFiles/DataFileExtensions.cs
+++ b/JECS/DataFiles/DataFileExtensions.cs
@@ -43,8 +43,9 @@ namespace JECS
 
             foreach (var m in type.GetValidMembers())
             {
-                var value = dataFile.GetNonGeneric(m.MemberType, m.Name);
-                m.SetValue(returnThis, value);
+                // Only overwrite the instantiated default field, when there is a value. This preserves default class assignments.
+                if (dataFile.TryGetNonGeneric(m.MemberType, m.Name, out var value))
+                    m.SetValue(returnThis, value);
             }
 
             return returnThis;
@@ -81,7 +82,9 @@ namespace JECS
 
             foreach (var m in type.GetValidMembers())
             {
-                var value = dataFile.GetNonGeneric(m.MemberType, m.Name, m.GetValue(defaultValuesSource));
+                // Always overwrite the instance. Either with the value acquired or a default provided
+                var value = dataFile.TryGetNonGeneric(m.MemberType, m.Name, out var output)
+                    ? output : m.GetValue(defaultValuesSource);
                 m.SetValue(returnThis, value);
             }
 

--- a/JECS/DataFiles/Memory Files/MemoryDataFile.cs
+++ b/JECS/DataFiles/Memory Files/MemoryDataFile.cs
@@ -38,7 +38,7 @@ namespace JECS.MemoryFiles
         /// <inheritdoc/>
         public override string Identifier { get; }
 
-        private string MemoryTextData = "";
+        private string MemoryTextData;
 
         /// <inheritdoc/>
         protected override string GetSavedText()

--- a/JECS/DataFiles/Memory Files/MemoryReadOnlyDataFile.cs
+++ b/JECS/DataFiles/Memory Files/MemoryReadOnlyDataFile.cs
@@ -13,7 +13,7 @@ namespace JECS.MemoryFiles
         /// Creates an empty ReadOnlyDataFile in memory.
         /// </summary>
         /// <remarks> why would you do this? </remarks>
-        public MemoryReadOnlyDataFile() : this(string.Empty) 
+        public MemoryReadOnlyDataFile() : this(string.Empty)
         {
         }
 
@@ -38,8 +38,8 @@ namespace JECS.MemoryFiles
         /// <inheritdoc/>
         public override string Identifier { get; }
 
-        private readonly string MemoryTextData = "";
-        
+        private readonly string MemoryTextData;
+
         /// <inheritdoc/>
         protected override string GetSavedText()
             => MemoryTextData;

--- a/JECS/DataFiles/ReadOnlyDataFile.cs
+++ b/JECS/DataFiles/ReadOnlyDataFile.cs
@@ -43,7 +43,7 @@ namespace JECS
                     return File.ReadAllText(FilePath);
                 }
 
-                return String.Empty;
+                return string.Empty;
             }
         }
 

--- a/JECS/DistributedData.cs
+++ b/JECS/DistributedData.cs
@@ -122,53 +122,6 @@ namespace JECS
         }
 
 
-        /// <summary> Get some data from our files, or return a default value if the data does not exist. </summary>
-        /// <param name="key"> What the data is labeled as within the file. </param>
-        /// <param name="defaultValue"> If the key does not exist in the file, this value is returned instead. </param>
-        public T Get<T>(string key, T defaultValue = default)
-            => TryGet<T>(key, out var output) ? output : defaultValue;
-
-        /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>
-        /// <param name="type"> The type to get the data as. </param>
-        /// <param name="key"> What the data is labeled as within the file. </param>
-        public object GetNonGeneric(Type type, string key)
-            => TryGetNonGeneric(type, key, out var output) ? output : type.GetDefaultValue();
-
-        /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>
-        /// <param name="type"> The type to get the data as. </param>
-        /// <param name="key"> What the data is labeled as within the file. </param>
-        /// <param name="defaultValue"> If the key does not exist in the file, this value is returned instead. </param>
-        public object GetNonGeneric(Type type, string key, object defaultValue)
-        {
-            if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
-                throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(defaultValue)}");
-
-            return TryGetNonGeneric(type, key, out var output) ? output : defaultValue;
-        }
-
-
-        /// <summary> Like <see cref="Get{T}(string, T)"/>, but works for nested paths instead of just the top level of the files. </summary>
-        public T GetAtPath<T>(params string[] path)
-            => GetAtPath((T)typeof(T).GetDefaultValue(), path);
-
-        /// <summary> Like <see cref="Get{T}(string, T)"/>, but works for nested paths instead of just the top level of the files. </summary>
-        public T GetAtPath<T>(T defaultValue, params string[] path)
-            => TryGetAtPath<T>(out var output, path) ? output : defaultValue;
-
-        /// <summary> Like <see cref="GetNonGeneric(Type, string)"/>, but works for nested paths instead of just the top level of the files. </summary>
-        public object GetAtPathNonGeneric(Type type, params string[] path)
-            => TryGetAtPathNonGeneric(type, out var value, path) ? value : type.GetDefaultValue();
-
-        /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but works for nested paths instead of just the top level of the files. </summary>
-        public object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
-        {
-            if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
-                throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(defaultValue)}");
-
-            return TryGetAtPathNonGeneric(type, out var value, path) ? value : defaultValue;
-        }
-
-
         /// <summary> Tries to get some data from our files. </summary>
         /// <param name="key"> They key for the data. </param>
         /// <param name="value"> Output data, if found value of type <typeparamref name="T"/> else <see langword="null"/>. </param>
@@ -203,6 +156,31 @@ namespace JECS
             return false;
         }
 
+        /// <summary> Get some data from our files, or return a default value if the data does not exist. </summary>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <param name="defaultValue"> If the key does not exist in the file, this value is returned instead. </param>
+        public T Get<T>(string key, T defaultValue = default)
+            => TryGet<T>(key, out var output) ? output : defaultValue;
+
+        /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>
+        /// <param name="type"> The type to get the data as. </param>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        public object GetNonGeneric(Type type, string key)
+            => TryGetNonGeneric(type, key, out var output) ? output : type.GetDefaultValue();
+
+        /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>
+        /// <param name="type"> The type to get the data as. </param>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <param name="defaultValue"> If the key does not exist in the file, this value is returned instead. </param>
+        public object GetNonGeneric(Type type, string key, object defaultValue)
+        {
+            if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
+                throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(defaultValue)}");
+
+            return TryGetNonGeneric(type, key, out var output) ? output : defaultValue;
+        }
+
+
         /// <summary> Tries to get some data from our files. </summary>
         /// <param name="value"> Output data, if found value of type <typeparamref name="T"/> else <see langword="null"/>. </param>
         /// <param name="path"> They path for the data. </param>
@@ -235,6 +213,27 @@ namespace JECS
 
             value = null;
             return false;
+        }
+
+        /// <summary> Like <see cref="Get{T}(string, T)"/>, but works for nested paths instead of just the top level of the files. </summary>
+        public T GetAtPath<T>(params string[] path)
+            => GetAtPath((T)typeof(T).GetDefaultValue(), path);
+
+        /// <summary> Like <see cref="GetNonGeneric(Type, string)"/>, but works for nested paths instead of just the top level of the files. </summary>
+        public object GetAtPathNonGeneric(Type type, params string[] path)
+            => TryGetAtPathNonGeneric(type, out var value, path) ? value : type.GetDefaultValue();
+
+        /// <summary> Like <see cref="Get{T}(string, T)"/>, but works for nested paths instead of just the top level of the files. </summary>
+        public T GetAtPath<T>(T defaultValue, params string[] path)
+            => TryGetAtPath<T>(out var output, path) ? output : defaultValue;
+
+        /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but works for nested paths instead of just the top level of the files. </summary>
+        public object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
+        {
+            if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
+                throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(defaultValue)}");
+
+            return TryGetAtPathNonGeneric(type, out var value, path) ? value : defaultValue;
         }
     }
 }

--- a/JECS/DistributedData.cs
+++ b/JECS/DistributedData.cs
@@ -126,13 +126,13 @@ namespace JECS
         /// <param name="key"> What the data is labeled as within the file. </param>
         /// <param name="defaultValue"> If the key does not exist in the file, this value is returned instead. </param>
         public T Get<T>(string key, T defaultValue = default)
-            => (T)GetNonGeneric(typeof(T), key, defaultValue);
+            => TryGet<T>(key, out var output) ? output : defaultValue;
 
         /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>
         /// <param name="type"> The type to get the data as. </param>
         /// <param name="key"> What the data is labeled as within the file. </param>
         public object GetNonGeneric(Type type, string key)
-            => GetNonGeneric(type, key, type.GetDefaultValue());
+            => TryGetNonGeneric(type, key, out var output) ? output : type.GetDefaultValue();
 
         /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>
         /// <param name="type"> The type to get the data as. </param>
@@ -143,62 +143,98 @@ namespace JECS
             if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
                 throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(defaultValue)}");
 
-            foreach (var file in DataSources)
-            {
-                if (file.KeyExists(key))
-                    return file.GetNonGeneric(type, key, defaultValue);
-            }
-
-            return defaultValue;
+            return TryGetNonGeneric(type, key, out var output) ? output : defaultValue;
         }
 
 
-        /// <summary> Like <see cref="Get{T}(string, T)"/>, but but works for nested paths instead of just the top level of the files. </summary>
+        /// <summary> Like <see cref="Get{T}(string, T)"/>, but works for nested paths instead of just the top level of the files. </summary>
+        public T GetAtPath<T>(params string[] path)
+            => GetAtPath((T)typeof(T).GetDefaultValue(), path);
+
+        /// <summary> Like <see cref="Get{T}(string, T)"/>, but works for nested paths instead of just the top level of the files. </summary>
         public T GetAtPath<T>(T defaultValue, params string[] path)
-            => (T)GetAtPathNonGeneric(typeof(T), defaultValue, path);
+            => TryGetAtPath<T>(out var output, path) ? output : defaultValue;
 
-        /// <summary> Like <see cref="GetNonGeneric(Type, string)"/>, but but works for nested paths instead of just the top level of the files. </summary>
+        /// <summary> Like <see cref="GetNonGeneric(Type, string)"/>, but works for nested paths instead of just the top level of the files. </summary>
         public object GetAtPathNonGeneric(Type type, params string[] path)
-            => GetAtPathNonGeneric(type, type.GetDefaultValue(), path);
+            => TryGetAtPathNonGeneric(type, out var value, path) ? value : type.GetDefaultValue();
 
-        /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but but works for nested paths instead of just the top level of the files. </summary>
+        /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but works for nested paths instead of just the top level of the files. </summary>
         public object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
         {
             if (defaultValue != null && !type.IsAssignableFrom(defaultValue.GetType()))
                 throw new InvalidCastException($"{nameof(type)} must be assignable from the type of {nameof(defaultValue)}");
 
-            foreach (var file in DataSources)
-            {
-                if (file.KeyExistsAtPath(path))
-                    return file.GetAtPathNonGeneric(type, defaultValue, path);
-            }
-
-            return defaultValue;
+            return TryGetAtPathNonGeneric(type, out var value, path) ? value : defaultValue;
         }
 
 
+        /// <summary> Tries to get some data from our files. </summary>
+        /// <param name="key"> They key for the data. </param>
+        /// <param name="value"> Output data, if found value of type <typeparamref name="T"/> else <see langword="null"/>. </param>
+        /// <typeparam name="T"> The type the data is expected to be. </typeparam>
+        /// <returns> <see langword="true"/>, if the key for data exists, <see langword="false"/> otherwise. </returns>
         public bool TryGet<T>(string key, out T value)
         {
-            if (!KeyExists(key))
+            foreach (var file in DataSources)
             {
-                value = default;
-                return false;
+                if (file.TryGet(key, out value))
+                    return true;
             }
 
-            value = Get<T>(key);
-            return true;
+            value = default;
+            return false;
         }
 
+        /// <summary> Tries to get some data from our files. </summary>
+        /// <param name="type"> The type the data is expected to be. </param>
+        /// <param name="key"> They key for the data. </param>
+        /// <param name="value"> Output data, if found value of type <paramref name="type"/> else <see langword="null"/>.</param>
+        /// <returns> <see langword="true"/>, if the key for data exists, <see langword="false"/> otherwise. </returns>
         public bool TryGetNonGeneric(Type type, string key, out object value)
         {
-            if (!KeyExists(key))
+            foreach (var file in DataSources)
             {
-                value = null;
-                return false;
+                if (file.TryGetNonGeneric(type, key, out value))
+                    return true;
             }
 
-            value = GetNonGeneric(type, key);
-            return true;
+            value = null;
+            return false;
+        }
+
+        /// <summary> Tries to get some data from our files. </summary>
+        /// <param name="value"> Output data, if found value of type <typeparamref name="T"/> else <see langword="null"/>. </param>
+        /// <param name="path"> They path for the data. </param>
+        /// <typeparam name="T"> The type the data is expected to be. </typeparam>
+        /// <returns> <see langword="true"/>, if the key for data exists, <see langword="false"/> otherwise. </returns>
+        public bool TryGetAtPath<T>(out T value, params string[] path)
+        {
+            foreach (var file in DataSources)
+            {
+                if (file.TryGetAtPath(out value, path))
+                    return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        /// <summary> Tries to get some data from our files. </summary>
+        /// <param name="type"> The type the data is expected to be. </param>
+        /// <param name="value"> Output data, if found value of type <paramref name="type"/> else <see langword="null"/>.</param>
+        /// <param name="path"> They path for the data. </param>
+        /// <returns> <see langword="true"/>, if the key for data exists, <see langword="false"/> otherwise. </returns>
+        public bool TryGetAtPathNonGeneric(Type type, out object value, params string[] path)
+        {
+            foreach (var file in DataSources)
+            {
+                if (file.TryGetAtPathNonGeneric(type, out value, path))
+                    return true;
+            }
+
+            value = null;
+            return false;
         }
     }
 }

--- a/JECS/DistributedData.cs
+++ b/JECS/DistributedData.cs
@@ -58,7 +58,7 @@ namespace JECS
         public static DistributedData CreateBySearching(DirectoryInfo directory, string searchPattern = "*", SearchOption searchOption = SearchOption.AllDirectories)
         {
             searchPattern = Path.ChangeExtension(searchPattern, Utilities.FileExtension);
-            
+
             var paths = new List<string>();
             foreach (var fileInfo in directory.EnumerateFiles(searchPattern, searchOption))
                 paths.Add(fileInfo.FullName);
@@ -125,7 +125,7 @@ namespace JECS
         /// <summary> Get some data from our files, or return a default value if the data does not exist. </summary>
         /// <param name="key"> What the data is labeled as within the file. </param>
         /// <param name="defaultValue"> If the key does not exist in the file, this value is returned instead. </param>
-        public T Get<T>(string key, T defaultValue = default) 
+        public T Get<T>(string key, T defaultValue = default)
             => (T)GetNonGeneric(typeof(T), key, defaultValue);
 
         /// <summary> Non-generic version of <see cref="Get{T}(string, T)"/>. You probably want to use <see cref="Get{T}(string, T)"/>. </summary>

--- a/JECS/DistributedDataExtensions.cs
+++ b/JECS/DistributedDataExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using JECS.Abstractions;
 using JECS.MemoryFiles;
-using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.IO;
 
 namespace JECS
 {

--- a/JECS/EasyJecs.cs
+++ b/JECS/EasyJecs.cs
@@ -23,7 +23,7 @@
             if (Utilities.JecsFileExists(filePath))
             {
                 var dataFile = new DataFile(filePath);
-                return dataFile.GetAsObject<T>(defaultValue);
+                return dataFile.GetAsObject(defaultValue);
             }
             else
             {

--- a/JECS/Parsing Logic/DataConverter.cs
+++ b/JECS/Parsing Logic/DataConverter.cs
@@ -125,6 +125,8 @@ namespace JECS.ParsingLogic
                     {
                         if (!(node is KeyNode))
                             throw new InvalidFileStructureException(dataFile, lineIndex, "top level lines must be key nodes");
+                        if (node.IndentationLevel != 0)
+                            throw new InvalidFileStructureException(dataFile, lineIndex, "top level nodes must not have indentation");
 
                         topLevelLines.Add(node);
                         KeyNode heck = node as KeyNode;

--- a/JECS/Parsing Logic/DataConverter.cs
+++ b/JECS/Parsing Logic/DataConverter.cs
@@ -1,6 +1,7 @@
 ﻿using JECS.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace JECS.ParsingLogic
@@ -36,13 +37,56 @@ namespace JECS.ParsingLogic
                     builder.Append(line.RawText);
                     builder.Append(Utilities.NewLine);
 
-                    if (line.RawText == string.Empty)
-                        lastWrittenLineWasEmpty = true;
+                    lastWrittenLineWasEmpty = line.RawText == string.Empty;
 
                     if (line is Node node)
                         RecursivelyBuildLines(node.ChildLines);
                 }
             }
+        }
+
+
+        private struct ParserData
+        {
+            public readonly List<Line> topLevelLines;
+            public readonly Dictionary<string, KeyNode> topLevelNodes;
+            public readonly Stack<Node> nestingNodeStack; // The top of the stack is the node that new nodes should be children of
+
+            private readonly ReadableDataFile dataFile;
+            private readonly IEnumerator<(int lineIndex, string line)> iterator;
+
+            private int lastLineIndex;
+
+            public ParserData(ReadableDataFile dataFile, string[] lines)
+            {
+                topLevelLines = new List<Line>();
+                topLevelNodes = new Dictionary<string, KeyNode>();
+                nestingNodeStack = new Stack<Node>();
+                this.dataFile = dataFile;
+                iterator = lines.Select((item, index) => (lineIndex: index, lines: item)).GetEnumerator();
+                lastLineIndex = 0; // Unity cannot (yet) do this manually. Wow an int default value.
+            }
+
+            public bool TryGetNextLine(out string output)
+            {
+                output = null;
+                if (!iterator.MoveNext())
+                    return false;
+
+                var (lineIndex, line) = iterator.Current;
+                if (line.Contains('\t'))
+                    throw new FormatException("A JECS file cannot contain tabs. Please use spaces instead.");
+
+                lastLineIndex = lineIndex;
+                output = line;
+                return true;
+            }
+
+            public bool TryPeekParentNode(out Node parentNode)
+                => nestingNodeStack.TryPeek(out parentNode);
+
+            public Exception ExceptionForLastLine(string message)
+                => new InvalidFileStructureException(dataFile, lastLineIndex, message);
         }
 
         /// <summary>
@@ -56,155 +100,172 @@ namespace JECS.ParsingLogic
         /// </summary>
         internal static (List<Line>, Dictionary<string, KeyNode>) DataStructureFromJecs(string[] lines, ReadableDataFile dataFile) // I am so, so sorry. If you need to understand this function for whatever reason... may god give you guidance.
         {
-            // If the file is empty
-            // Do this because otherwise new files are created with a newline at the top
+            // Detect empty files and create a file without any lines.
+            // This prevents a final newline from being generated in a file which original was empty.
             if (lines.Length == 1 && lines[0] == "")
                 return (new List<Line>(), new Dictionary<string, KeyNode>());
 
-
-            var topLevelLines = new List<Line>();
-            var topLevelNodes = new Dictionary<string, KeyNode>();
-
-            var nestingNodeStack = new Stack<Node>(); // The top of the stack is the node that new nodes should be children of
-
-            bool doingMultiLineString = false;
-            int multiLineStringIndentationLevel = -1;
+            var parserData = new ParserData(dataFile, lines);
 
             // Parse the input line by line
-            for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+            while (parserData.TryGetNextLine(out var line))
             {
-                var line = lines[lineIndex];
-                if (line.Contains('\t'))
-                    throw new FormatException("a JECS file cannot contain tabs. Please use spaces instead.");
-
-                if (doingMultiLineString)
-                {
-                    var parentNode = nestingNodeStack.Peek();
-
-                    if (parentNode.ChildNodeType != NodeChildrenType.MultiLineString)
-                        throw new Exception("oh no, we were supposed to be doing a multi-line string but the top of the node stack isn't a multi-line string node!");
-
-                    var newBoi = new MultiLineStringNode(rawText: line, dataFile);
-
-                    if (parentNode.ChildNodes.Count == 0)
-                    {
-                        // If this is the first line of the multi-line string, it determines the indentation level.
-                        // However, that indentation level must be greater than the parent's.
-                        multiLineStringIndentationLevel = newBoi.IndentationLevel;
-
-                        if (multiLineStringIndentationLevel <= parentNode.IndentationLevel)
-                            throw new InvalidFileStructureException(dataFile, lineIndex, "multi-line string lines must have an indentation level greater than their parent");
-                    }
-                    else
-                    {
-                        if (newBoi.IndentationLevel != multiLineStringIndentationLevel)
-                            throw new InvalidFileStructureException(dataFile, lineIndex, "multi-line string lines must all have the same indentation level");
-                    }
-
-                    parentNode.AddChild(newBoi);
-
-                    if (newBoi.IsTerminator)
-                    {
-                        doingMultiLineString = false;
-                        multiLineStringIndentationLevel = -1;
-
-                        nestingNodeStack.Pop();
-                    }
-
-                    continue;
-                }
-
                 if (LineHasData(line))
                 {
-                    Node node = GetNodeFromLine(line, dataFile, lineIndex);
+                    // The line does have data, thus we can create a data node for it.
+                    var newNode = GetNodeFromLine(parserData, line, dataFile);
+                    // This new node has to be injected into the node tree.
+                    AppropriatelyInjectDataNodeIntoTree(parserData, newNode); // This method is the only place, that will remove nodes from the stack.
 
-                    addNodeInAppropriatePlaceInStack:
+                    // Nodes with values cannot have children. Thus, only when there is no value, add it onto the stack.
+                    if (!newNode.HasValue)
+                        parserData.nestingNodeStack.Push(newNode); // This is the only call, which adds nodes onto the stack.
 
-                    if (nestingNodeStack.Count == 0) // If this is a top-level node
-                    {
-                        if (node is not KeyNode keyNode)
-                            throw new InvalidFileStructureException(dataFile, lineIndex, "top level lines must be key nodes");
-                        if (keyNode.IndentationLevel != 0)
-                            throw new InvalidFileStructureException(dataFile, lineIndex, "top level nodes must not have indentation");
-
-                        topLevelLines.Add(node);
-
-                        try
-                        {
-                            topLevelNodes.Add(keyNode.Key, keyNode);
-                        }
-                        catch (ArgumentException)
-                        {
-                            throw new InvalidFileStructureException(dataFile, lineIndex, $"multiple top level keys called '{keyNode.Key}'");
-                        }
-                    }
-                    else // If this is NOT a top-level node
-                    {
-                        int stackTopIndentation = nestingNodeStack.Peek().IndentationLevel;
-                        int lineIndentation = line.GetIndentationLevel();
-
-                        if (lineIndentation > stackTopIndentation) // If this should be a child of the stack top
-                        {
-                            Node newParent = nestingNodeStack.Peek();
-                            if (newParent.ChildNodes.Count == 0) // If this is the first child of the parent, assign the parent's child type
-                            {
-                                if (node is KeyNode)
-                                    newParent.ChildNodeType = NodeChildrenType.Key;
-                                else if (node is ListNode)
-                                    newParent.ChildNodeType = NodeChildrenType.List;
-                                else
-                                    throw new Exception("what the heck?");
-                            }
-                            else // If the parent already has children, check for errors with this line
-                            {
-                                CheckNewSiblingForErrors(child: node, newParent: newParent, dataFile, lineIndex);
-                            }
-
-                            try
-                            {
-                                newParent.AddChild(node);
-                            }
-                            catch (ArgumentException)
-                            {
-                                throw new InvalidFileStructureException(dataFile, lineIndex, $"multiple sibling keys called '{((KeyNode)node).Key}' (indentation level {lineIndentation})");
-                            }
-                        }
-                        else // If this should NOT be a child of the stack top
-                        {
-                            nestingNodeStack.Pop();
-                            goto addNodeInAppropriatePlaceInStack;
-                        }
-                    }
-
-                    if (!node.HasValue) // If this node can have children, but is not the start of a multi-line string
-                        nestingNodeStack.Push(node);
-
-                    if (node.Value == MultiLineStringNode.Terminator) // If this is the start of a multi line string
-                    {
-                        nestingNodeStack.Push(node);
-                        node.ChildNodeType = NodeChildrenType.MultiLineString;
-
-                        doingMultiLineString = true;
-                    }
+                    // Except a multi-line string, it can have children. But that is entirely handled in its own method.
+                    // Multi-line strings always start with a value """
+                    if (newNode.Value == MultiLineStringNode.Terminator)
+                        ParseMultiLineString(parserData, dataFile, newNode); // The only other method grabbing new lines.
                 }
                 else // Line has no data
                 {
-                    Line NoDataLine = new Line(rawText: line);
-
-                    if (nestingNodeStack.Count == 0)
-                        topLevelLines.Add(NoDataLine);
-                    else
-                        nestingNodeStack.Peek().AddChild(NoDataLine);
+                    var noDataLine = new Line(line);
+                    AppropriatelyInjectNoDataNodeIntoTree(parserData, noDataLine);
                 }
             }
 
-            if (doingMultiLineString)
-                throw new InvalidFileStructureException(dataFile, lines.Length, "multi-line string must be terminated");
-
-            return (topLevelLines, topLevelNodes);
+            return (parserData.topLevelLines, parserData.topLevelNodes);
         }
 
+        private static void AppropriatelyInjectNoDataNodeIntoTree(ParserData parserData, Line noDataLine)
+        {
+            if (parserData.TryPeekParentNode(out var parentNode))
+                parentNode.AddChild(noDataLine);
+            else
+                parserData.topLevelLines.Add(noDataLine);
+        }
 
+        private static void AppropriatelyInjectDataNodeIntoTree(ParserData parserData, Node nodeToAdd)
+        {
+            // This method will try to add the node to a parent.
+            // For that it will check the stack top-down until it finds a suitable parent.
+            // Suitable means, the parent has a lower indentation than the new child node.
+            // If there is no such parent (meaning the only stack entry is a sibling), then a new top-level node is added.
+            // This method won't add anything to the stack! After adding a top-level node, it leaves a clean table.
+            while (true)
+            {
+                if (!parserData.TryPeekParentNode(out var potentialParentNode))
+                {
+                    // There is no (potential) parent node, thus we are now adding a top-level node.
+                    AddTopLevelNodeToTree(parserData, nodeToAdd);
+                    return;
+                }
+
+                // We have a potential parent node. Compare indentations to see if it is actually one.
+                if (nodeToAdd.IndentationLevel > potentialParentNode.IndentationLevel)
+                {
+                    // Our node has a HIGHER indentation than the potential parent node, meaning the new node is an actual child of the (potential) parent.
+                    AddChildNodeToTree(parserData, potentialParentNode, nodeToAdd);
+                    return;
+                }
+
+                // Remaining indentation possibilities:
+                // - LOWER than potential parent, this means it is a sibling of any parent before that, or it is a top node.
+                // - SAME as potential parent, this means it is a sibling of the previous (potential) parent node.
+                // In either case, the previously potential parent node does not have any further child nodes, drop it from the stack.
+                parserData.nestingNodeStack.Pop();
+                // And do the same comparisons again for the next potential parent...
+            }
+        }
+
+        private static void AddTopLevelNodeToTree(ParserData parserData, Node node)
+        {
+            if (node is not KeyNode keyNode)
+                throw parserData.ExceptionForLastLine("Top level lines must be key nodes");
+            if (keyNode.IndentationLevel != 0)
+                throw parserData.ExceptionForLastLine("Top level nodes must not have indentation");
+
+            parserData.topLevelLines.Add(node);
+            if (!parserData.topLevelNodes.TryAdd(keyNode.Key, keyNode))
+                throw parserData.ExceptionForLastLine($"Multiple top level keys called '{keyNode.Key}'");
+        }
+
+        private static void AddChildNodeToTree(ParserData parserData, Node parent, Node child)
+        {
+            if (parent.ChildNodes.Count == 0)
+            {
+                // A parent node does not control the type of its child nodes. But all children must be of the same type.
+                // Thus, the very first child will store its own type in the parent (ChildNodeType), so that future siblings type can be checked.
+                parent.ChildNodeType = child switch
+                {
+                    KeyNode => NodeChildrenType.Key,
+                    ListNode => NodeChildrenType.List,
+                    _ => throw new Exception($"Impossible to reach code. At this point only Key/List nodes should reach this method. Got '{child.GetType()}' instead")
+                };
+            }
+            else
+            {
+                // As there already have been previous siblings, make sure that the new sibling has same indentation and type.
+                var sibling = parent.ChildNodes[0];
+
+                // Sibling nodes must have exactly the same indentation as its previous sibling, thus by incrementation the first sibling.
+                if (child.IndentationLevel != sibling.IndentationLevel)
+                    throw parserData.ExceptionForLastLine("Line did not have the same indentation as its assumed sibling");
+
+                // Ensure that the new siblings have the same type.
+                // This check also checks for crude errors, where something went horribly wrong.
+                if (// Expected checks:
+                    parent.ChildNodeType == NodeChildrenType.Key && child is not KeyNode
+                    || parent.ChildNodeType == NodeChildrenType.List && child is not ListNode
+                    // Fatal failure checks:
+                    || parent.ChildNodeType == NodeChildrenType.MultiLineString
+                    || parent.ChildNodeType == NodeChildrenType.None)
+                    throw parserData.ExceptionForLastLine("Line did not match the child type of its parent");
+            }
+
+            // All good, add the child (except not all good, and we get a duplicate key...)
+            if(!parent.TryAddChild(child))
+                throw parserData.ExceptionForLastLine($"Multiple sibling keys called '{((KeyNode)child).Key}' (indentation level {child.IndentationLevel})");
+        }
+
+        private static void ParseMultiLineString(ParserData parserData, ReadableDataFile dataFile, Node parentNode)
+        {
+            // Set the parent node type to MLS, this can be/is used for validation later on
+            parentNode.ChildNodeType = NodeChildrenType.MultiLineString;
+
+            // The target indentation is only known with the very first data/text line.
+            int multiLineStringIndentationLevel = -1;
+
+            // Process every line, until another MLS terminator is detected.
+            while (parserData.TryGetNextLine(out string line))
+            {
+                var childNode = new MultiLineStringNode(line, dataFile);
+
+                if (parentNode.ChildNodes.Count == 0)
+                {
+                    // If this is the first line of the multi-line string, it determines the indentation level.
+                    // However, that indentation level must be greater than the parent's.
+                    multiLineStringIndentationLevel = childNode.IndentationLevel;
+
+                    if (multiLineStringIndentationLevel <= parentNode.IndentationLevel)
+                        throw parserData.ExceptionForLastLine("Multi-line string lines must have an indentation level greater than their parent");
+                }
+                else
+                {
+                    if (childNode.IndentationLevel != multiLineStringIndentationLevel)
+                        throw parserData.ExceptionForLastLine("Multi-line string lines must all have the same indentation level");
+                }
+
+                parentNode.AddChild(childNode);
+
+                // Found the terminator (closer) of this multi-line string. The iteration is over and all lines are processed.
+                // Proceed with the main loop outside of this method.
+                if (childNode.IsTerminator)
+                    return;
+            }
+
+            // If the code reaches this point, there was no closing terminator for this MLS.
+            throw parserData.ExceptionForLastLine("Multi-line string must be terminated");
+        }
 
         private static bool LineHasData(string line)
         {
@@ -212,50 +273,32 @@ namespace JECS.ParsingLogic
             return line.Length != 0 && line[0] != '#';
         }
 
-        private static Node GetNodeFromLine(string line, ReadableDataFile file, int lineNumber)
+        private enum DataLineType { None, Key, List }
+
+        private static Node GetNodeFromLine(ParserData parserData, string line, ReadableDataFile file)
         {
             var dataType = GetDataLineType(line);
-            switch (dataType)
+            return dataType switch
             {
-                case DataLineType.key:
-                    return new KeyNode(rawText: line, file);
-
-                case DataLineType.list:
-                    return new ListNode(rawText: line, file);
-
-                default:
-                    throw new InvalidFileStructureException(file, lineNumber, "format error");
-            }
+                DataLineType.Key => new KeyNode(rawText: line, file),
+                DataLineType.List => new ListNode(rawText: line, file),
+                _ => throw parserData.ExceptionForLastLine("Invalid line type, lines with data must be list or key nodes")
+            };
         }
 
-        private static void CheckNewSiblingForErrors(Node child, Node newParent, ReadableDataFile dataFile, int lineNumber)
-        {
-            Node sibling = newParent.ChildNodes[0];
-            if (child.IndentationLevel != sibling.IndentationLevel) // if there is a mismatch between the new node's indentation and its sibling's
-                throw new InvalidFileStructureException(dataFile, lineNumber, "Line did not have the same indentation as its assumed sibling");
-
-            if (  // if there is a mismatch between the new node's type and its sibling's
-                   newParent.ChildNodeType == NodeChildrenType.Key && child is not KeyNode
-                || newParent.ChildNodeType == NodeChildrenType.List && child is not ListNode
-                || newParent.ChildNodeType == NodeChildrenType.MultiLineString
-                || newParent.ChildNodeType == NodeChildrenType.None)
-                throw new InvalidFileStructureException(dataFile, lineNumber, $"Line did not match the child type of its parent");
-        }
-
-        private enum DataLineType { none, key, list }
         private static DataLineType GetDataLineType(string line)
         {
             var trimmed = line.Trim();
             if (trimmed.Length == 0)
-                return DataLineType.none;
+                return DataLineType.None;
             if (trimmed[0] == '#')
-                return DataLineType.none;
+                return DataLineType.None;
             if (trimmed[0] == '-')
-                return DataLineType.list;
+                return DataLineType.List;
             if (trimmed.Contains(':'))
-                return DataLineType.key;
+                return DataLineType.Key;
 
-            return DataLineType.none;
+            return DataLineType.None;
         }
     }
 }

--- a/JECS/Parsing Logic/DataConverter.cs
+++ b/JECS/Parsing Logic/DataConverter.cs
@@ -198,6 +198,9 @@ namespace JECS.ParsingLogic
                 }
             }
 
+            if (doingMultiLineString)
+                throw new InvalidFileStructureException(dataFile, lines.Length, "multi-line string must be terminated");
+
             return (topLevelLines, topLevelNodes);
         }
 

--- a/JECS/Parsing Logic/DataConverter.cs
+++ b/JECS/Parsing Logic/DataConverter.cs
@@ -1,7 +1,6 @@
-using JECS.Abstractions;
+﻿using JECS.Abstractions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JECS.ParsingLogic
@@ -123,21 +122,20 @@ namespace JECS.ParsingLogic
 
                     if (nestingNodeStack.Count == 0) // If this is a top-level node
                     {
-                        if (!(node is KeyNode))
+                        if (node is not KeyNode keyNode)
                             throw new InvalidFileStructureException(dataFile, lineIndex, "top level lines must be key nodes");
-                        if (node.IndentationLevel != 0)
+                        if (keyNode.IndentationLevel != 0)
                             throw new InvalidFileStructureException(dataFile, lineIndex, "top level nodes must not have indentation");
 
                         topLevelLines.Add(node);
-                        KeyNode heck = node as KeyNode;
 
                         try
                         {
-                            topLevelNodes.Add(heck.Key, heck);
+                            topLevelNodes.Add(keyNode.Key, keyNode);
                         }
                         catch (ArgumentException)
                         {
-                            throw new InvalidFileStructureException(dataFile, lineIndex, $"multiple top level keys called '{heck.Key}'");
+                            throw new InvalidFileStructureException(dataFile, lineIndex, $"multiple top level keys called '{keyNode.Key}'");
                         }
                     }
                     else // If this is NOT a top-level node
@@ -168,7 +166,7 @@ namespace JECS.ParsingLogic
                             }
                             catch (ArgumentException)
                             {
-                                throw new InvalidFileStructureException(dataFile, lineIndex, $"multiple sibling keys called '{(node as KeyNode).Key}' (indentation level {lineIndentation})");
+                                throw new InvalidFileStructureException(dataFile, lineIndex, $"multiple sibling keys called '{((KeyNode)node).Key}' (indentation level {lineIndentation})");
                             }
                         }
                         else // If this should NOT be a child of the stack top
@@ -218,7 +216,7 @@ namespace JECS.ParsingLogic
             {
                 case DataLineType.key:
                     return new KeyNode(rawText: line, file);
-                    
+
                 case DataLineType.list:
                     return new ListNode(rawText: line, file);
 
@@ -234,8 +232,8 @@ namespace JECS.ParsingLogic
                 throw new InvalidFileStructureException(dataFile, lineNumber, "Line did not have the same indentation as its assumed sibling");
 
             if (  // if there is a mismatch between the new node's type and its sibling's
-                   newParent.ChildNodeType == NodeChildrenType.Key && !(child is KeyNode)
-                || newParent.ChildNodeType == NodeChildrenType.List && !(child is ListNode)
+                   newParent.ChildNodeType == NodeChildrenType.Key && child is not KeyNode
+                || newParent.ChildNodeType == NodeChildrenType.List && child is not ListNode
                 || newParent.ChildNodeType == NodeChildrenType.MultiLineString
                 || newParent.ChildNodeType == NodeChildrenType.None)
                 throw new InvalidFileStructureException(dataFile, lineNumber, $"Line did not match the child type of its parent");
@@ -245,10 +243,14 @@ namespace JECS.ParsingLogic
         private static DataLineType GetDataLineType(string line)
         {
             var trimmed = line.Trim();
-            if (trimmed.Length == 0) return DataLineType.none;
-            if (trimmed[0] == '#') return DataLineType.none;
-            if (trimmed[0] == '-') return DataLineType.list;
-            if (trimmed.Contains(':')) return DataLineType.key;
+            if (trimmed.Length == 0)
+                return DataLineType.none;
+            if (trimmed[0] == '#')
+                return DataLineType.none;
+            if (trimmed[0] == '-')
+                return DataLineType.list;
+            if (trimmed.Contains(':'))
+                return DataLineType.key;
 
             return DataLineType.none;
         }

--- a/JECS/Parsing Logic/DontSaveThisAttribute.cs
+++ b/JECS/Parsing Logic/DontSaveThisAttribute.cs
@@ -6,7 +6,7 @@ namespace JECS
     /// Public fields and properties with this attribute will NOT be saved and loaded by JECS.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false)]
-    public class DontSaveThisAttribute : Attribute 
-    { 
+    public class DontSaveThisAttribute : Attribute
+    {
     }
 }

--- a/JECS/Parsing Logic/NodeManager.cs
+++ b/JECS/Parsing Logic/NodeManager.cs
@@ -1,4 +1,4 @@
-using JECS.ParsingLogic.CollectionTypes;
+﻿using JECS.ParsingLogic.CollectionTypes;
 using System;
 
 namespace JECS.ParsingLogic
@@ -13,7 +13,7 @@ namespace JECS.ParsingLogic
         {
             if (data == null && !type.IsNullableType())
                 throw new Exception($"There's been some kind of coding mistake: {nameof(data)} is null, but type {type} is not nullable.");
-            
+
             if (data != null && !type.IsAssignableFrom(data.GetType()))
                 throw new Exception($"There's been some kind of coding mistake: {nameof(data)} is of type {data.GetType()}, which is not assignable to type {type}.");
 
@@ -106,11 +106,11 @@ namespace JECS.ParsingLogic
                 {
                     return retrieveDataFunction.Invoke();
                 }
-                catch (CannotRetrieveDataFromNodeException deeperException)
+                catch (CannotRetrieveDataFromNodeException)
                 {
                     // If there's a parsing error deeper in the tree, we want to throw *that* error, so the user gets a line
                     // number appropriate to the actual error.
-                    throw deeperException;
+                    throw;
                 }
                 catch
                 {

--- a/JECS/Parsing Logic/Nodes/KeyNode.cs
+++ b/JECS/Parsing Logic/Nodes/KeyNode.cs
@@ -1,4 +1,4 @@
-using JECS.Abstractions;
+﻿using JECS.Abstractions;
 using System;
 
 namespace JECS.ParsingLogic
@@ -59,7 +59,7 @@ namespace JECS.ParsingLogic
 
                 SetDataText(
                     text.Substring(startIndex: 0, length: colonIndex + spacesAfterColon + 1) + value
-                    );
+                );
             }
         }
 

--- a/JECS/Parsing Logic/Nodes/Line.cs
+++ b/JECS/Parsing Logic/Nodes/Line.cs
@@ -19,10 +19,12 @@ namespace JECS.ParsingLogic
             get => RawText.GetIndentationLevel();
             set
             {
-                if (value < 0) throw new ArgumentOutOfRangeException($"node indents must be at least 0. You tried to set it to {value}");
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException($"node indents must be at least 0. You tried to set it to {value}");
 
                 var indent = RawText.GetIndentationLevel();
-                if (value == indent) return;
+                if (value == indent)
+                    return;
 
                 var diff = value - indent;
                 if (diff > 0)

--- a/JECS/Parsing Logic/Nodes/ListNode.cs
+++ b/JECS/Parsing Logic/Nodes/ListNode.cs
@@ -43,7 +43,7 @@ namespace JECS.ParsingLogic
 
                 SetDataText(
                     text.Substring(startIndex: 0, length: dashIndex + spacesAfterDash + 1) + value
-                    );
+                );
             }
         }
 

--- a/JECS/Parsing Logic/Nodes/MultiLineStringNode.cs
+++ b/JECS/Parsing Logic/Nodes/MultiLineStringNode.cs
@@ -20,12 +20,12 @@ namespace JECS.ParsingLogic
         }
 
 
-        public static readonly string Terminator = "\"\"\"";
+        public const string Terminator = "\"\"\"";
 
         public bool IsTerminator => Value == Terminator;
         public void MakeTerminator() => Value = Terminator;
 
 
-        public static readonly string NoLineBreakIndicator = @"\";
+        public const string NoLineBreakIndicator = @"\";
     }
 }

--- a/JECS/Parsing Logic/Nodes/Node.cs
+++ b/JECS/Parsing Logic/Nodes/Node.cs
@@ -35,14 +35,14 @@ namespace JECS.ParsingLogic
         /// <summary> This constructor used when loading lines from file </summary>
         public Node(string rawText, ReadableDataFile file) : base(rawText)
         {
-            this.File = file ?? throw new ArgumentNullException("Nodes must belong to a file");
+            this.File = file ?? throw new ArgumentNullException(nameof(file), "Nodes must belong to a file");
             this.FileStyleRef = file as ReadableWritableDataFile;
         }
 
         /// <summary> This constructor used when creating new lines to add to the file </summary>
         public Node(int indentation, ReadableDataFile file)
         {
-            this.File = file ?? throw new ArgumentNullException("Nodes must belong to a file");
+            this.File = file ?? throw new ArgumentNullException(nameof(file), "Nodes must belong to a file");
             this.FileStyleRef = file as ReadableWritableDataFile;
 
             this.IndentationLevel = indentation;
@@ -58,7 +58,7 @@ namespace JECS.ParsingLogic
 
             foreach (var node in ChildNodes)
             {
-                var keyNode = node as KeyNode;
+                var keyNode = (KeyNode)node;
                 if (keyNode.Key == name) return keyNode;
             }
 
@@ -107,9 +107,9 @@ namespace JECS.ParsingLogic
             // If we already have a child, match new indentation level to that child.
             if (this.ChildNodes.Count > 0)
                 return this.ChildNodes[0].IndentationLevel;
-            
+
             // Otherwise, increase the indentation level in accordance with the FileStyle.
-            return this.IndentationLevel + Style.IndentationInterval; 
+            return this.IndentationLevel + Style.IndentationInterval;
         }
 
         private void EnsureProperChildType(NodeChildrenType expectedType)
@@ -128,7 +128,7 @@ namespace JECS.ParsingLogic
 
 
         public bool HasValue => !Value.IsNullOrEmpty();
-        public void ClearValue() => Value = String.Empty;
+        public void ClearValue() => Value = string.Empty;
 
         public bool HasChildNodes => ChildNodes.Count > 0;
         public void ClearChildren()
@@ -171,8 +171,8 @@ namespace JECS.ParsingLogic
 
         public void CapChildCount(int count)
         {
-            if (count < 0) 
-                throw new ArgumentOutOfRangeException("stop it");
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), "Child cap count cannot be negative");
 
             while (ChildNodes.Count > count)
             {
@@ -188,14 +188,14 @@ namespace JECS.ParsingLogic
                 yield break;
 
             foreach (var node in ChildNodes)
-                yield return (node as KeyNode).Key;
+                yield return ((KeyNode)node).Key;
         }
 
 
 
         public string GetDataText()
         {
-            if (RawText.IsWhitespace()) 
+            if (RawText.IsWhitespace())
                 return String.Empty;
 
             return RawText.Substring(DataStartIndex, DataEndIndex - DataStartIndex)
@@ -217,7 +217,7 @@ namespace JECS.ParsingLogic
             {
                 var text = RawText;
 
-                if (text.IsWhitespace()) 
+                if (text.IsWhitespace())
                     return text.Length;
 
                 // find the first # in the string

--- a/JECS/Parsing Logic/Nodes/Node.cs
+++ b/JECS/Parsing Logic/Nodes/Node.cs
@@ -253,6 +253,12 @@ namespace JECS.ParsingLogic
                 // remove trailing spaces
                 text = text.TrimEnd();
 
+                // When there is no data, but only indentation & a comment. Then the previous trim statement would have removed the whole content.
+                // In that case, we must not return an index below indentation count (due to that causing a negative message length).
+                // Instead, return: the indentation == basically where the pound sign is == where the data would have started.
+                if (text.Length == 0)
+                    return PoundSignIndex;
+
                 return text.Length;
             }
         }

--- a/JECS/Parsing Logic/Nodes/Node.cs
+++ b/JECS/Parsing Logic/Nodes/Node.cs
@@ -52,6 +52,25 @@ namespace JECS.ParsingLogic
         protected bool StyleNotYetApplied = false;
 
 
+        public bool TryGetChildAddressedByName(string name, out KeyNode outNode)
+        {
+            EnsureProperChildType(NodeChildrenType.Key);
+
+            foreach (var node in ChildNodes)
+            {
+                var keyNode = (KeyNode)node;
+                if (keyNode.Key == name)
+                {
+                    outNode = keyNode;
+                    return true;
+                }
+            }
+
+            outNode = null;
+            return false;
+        }
+
+        /// <summary> Returns an existing child with key <paramref name="name"/>. If it does not exist, it will be created and injected first. </summary>
         public KeyNode GetChildAddressedByName(string name)
         {
             EnsureProperChildType(NodeChildrenType.Key);
@@ -177,10 +196,12 @@ namespace JECS.ParsingLogic
 
         public void RemoveChild(string key)
         {
+            if (ChildNodeType != NodeChildrenType.Key)
+                return;
+
             foreach (var node in ChildNodes)
             {
-                var keyNode = node as KeyNode;
-                if (keyNode?.Key == key)
+                if (((KeyNode)node).Key == key)
                 {
                     _ChildNodes.Remove(node);
                     _ChildLines.Remove(node);

--- a/JECS/Parsing Logic/Nodes/Node.cs
+++ b/JECS/Parsing Logic/Nodes/Node.cs
@@ -143,6 +143,26 @@ namespace JECS.ParsingLogic
         public bool ContainsChildNode(string key)
             => GetChildKeys().Contains(key);
 
+        /// <summary> Tries to add a child node, without causing a KeyNode collision. </summary>
+        /// <param name="newNode"> The new node to add as child to this node. </param>
+        /// <returns> <see langword="false"/> when a key collision occurred, otherwise <see langword="false"/> (successfully added new node). </returns>
+        /// <remarks> <b>IMPORTANT</b>: It is callers responsibility to ensure the ChildType is correct. This is an internal class. </remarks>
+        public bool TryAddChild(Node newNode)
+        {
+            if (ChildNodeType == NodeChildrenType.Key
+                && newNode is KeyNode keyNode
+                && ContainsChildNode(keyNode.Key))
+                return false;
+
+            _ChildNodes.Add(newNode);
+            _ChildLines.Add(newNode);
+            return true;
+        }
+
+        /// <summary> Adds a child line. </summary>
+        /// <param name="newLine"> The new line to add as a child to this node. </param>
+        /// <exception cref="ArgumentException"> When the child is a <see cref="KeyNode"/> and the key is already registered in this node. </exception>
+        /// <remarks> <b>IMPORTANT</b>: It is callers responsibility to ensure the ChildType is correct. This is an internal class. </remarks>
         public void AddChild(Line newLine)
         {
             if (this.ChildNodeType == NodeChildrenType.Key && newLine is KeyNode keyNode && this.ContainsChildNode(keyNode.Key))

--- a/JECS/Parsing Logic/Types/Base Types/BaseTypeLogic.cs
+++ b/JECS/Parsing Logic/Types/Base Types/BaseTypeLogic.cs
@@ -23,7 +23,7 @@ namespace JECS
             if (value is T item)
                 return SerializeItem(item, style);
 
-            throw new ArgumentException($"Wrong type!!!!");
+            throw new ArgumentException("Wrong type!!!!");
         }
         public abstract string SerializeItem(T value, FileStyle style);
 
@@ -43,7 +43,7 @@ namespace JECS
             if (value is T item)
                 return SerializeItem(item);
 
-            throw new ArgumentException($"Wrong type!!!!");
+            throw new ArgumentException("Wrong type!!!!");
         }
         public abstract string SerializeItem(T value);
 

--- a/JECS/Parsing Logic/Types/Base Types/BaseTypesManager.cs
+++ b/JECS/Parsing Logic/Types/Base Types/BaseTypesManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using JECS.BuiltInBaseTypeLogics;
 
 namespace JECS.ParsingLogic
@@ -23,14 +22,14 @@ namespace JECS.ParsingLogic
                 RegisterBaseType(new BaseTypeLogic_String());
                 RegisterBaseType(new BaseTypeLogic_Type());
                 RegisterBaseType(new BaseTypeLogic_Version());
-                
+
                 RegisterBaseType(new BaseTypeLogic_DirectoryInfo());
                 RegisterBaseType(new BaseTypeLogic_FileInfo());
-                
+
                 RegisterBaseType(new BaseTypeLogic_Float());
                 RegisterBaseType(new BaseTypeLogic_Double());
                 RegisterBaseType(new BaseTypeLogic_Decimal());
-                
+
                 RegisterBaseType(new BaseTypeLogic_Sbyte());
                 RegisterBaseType(new BaseTypeLogic_Byte());
                 RegisterBaseType(new BaseTypeLogic_Short());
@@ -42,21 +41,21 @@ namespace JECS.ParsingLogic
                 RegisterBaseType(new BaseTypeLogic_BigInt());
             }
         }
-        
+
         private static readonly Dictionary<Type, BaseTypeLogic> RegisteredBaseTypeLogics = new Dictionary<Type, BaseTypeLogic>();
 
         public static void RegisterBaseType(BaseTypeLogic logic)
         {
             if (logic == null)
                 throw new ArgumentNullException(nameof(logic));
-            
+
             if (RegisteredBaseTypeLogics.ContainsKey(logic.ApplicableType))
                 throw new Exception($"Failed to register base type with logic {logic.GetType()}. There is already a base type logic for type {logic.ApplicableType}. The existing logic is of type {RegisteredBaseTypeLogics[logic.ApplicableType]}");
 
             RegisteredBaseTypeLogics.Add(logic.ApplicableType, logic);
         }
-        
-        
+
+
 
         /// <summary> Returns true if the type is a registered base type. </summary>
         public static bool IsBaseType(Type type)
@@ -122,7 +121,6 @@ namespace JECS.ParsingLogic
                 return false;
             }
         }
-
 
 
 

--- a/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/BaseTypeLogic_Bool.cs
+++ b/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/BaseTypeLogic_Bool.cs
@@ -30,10 +30,10 @@ namespace JECS.BuiltInBaseTypeLogics
         {
             text = text.ToLower();
 
-            if (TrueStrings.Contains(text)) 
+            if (TrueStrings.Contains(text))
                 return true;
 
-            if (FalseStrings.Contains(text)) 
+            if (FalseStrings.Contains(text))
                 return false;
 
             throw new FormatException($"Cannot parse text {text} as boolean");

--- a/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/BaseTypeLogic_String.cs
+++ b/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/BaseTypeLogic_String.cs
@@ -1,5 +1,4 @@
 ﻿using JECS.ParsingLogic;
-using System;
 
 namespace JECS.BuiltInBaseTypeLogics
 {
@@ -8,7 +7,7 @@ namespace JECS.BuiltInBaseTypeLogics
         public override string SerializeItem(string value, FileStyle style)
         {
             if (value.IsNullOrEmpty())
-                return String.Empty;
+                return string.Empty;
 
             value = value.Replace("\t", "    "); // JECS files cannot contain tabs. Prevent saving strings with tabs in them.
 

--- a/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/BaseTypeLogic_Type.cs
+++ b/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/BaseTypeLogic_Type.cs
@@ -49,7 +49,7 @@ namespace JECS.BuiltInBaseTypeLogics
             string typeFullName = type.FullName;
 
             // You get this when you're recursively getting the generic parameters of an unbound generic type
-            if (String.IsNullOrEmpty(typeFullName))
+            if (string.IsNullOrEmpty(typeFullName))
                 return typeFullName;
 
             if (type.IsArray)
@@ -66,7 +66,7 @@ namespace JECS.BuiltInBaseTypeLogics
             if (type.IsGenericType)
             {
                 string typeNameWithoutGenerics = typeFullName.Split('`')[0];
-                string genericArguments = String.Join(", ", type.GetGenericArguments().Select(GetCsharpTypeName));
+                string genericArguments = string.Join(", ", type.GetGenericArguments().Select(GetCsharpTypeName));
 
                 return typeNameWithoutGenerics + "<" + genericArguments + ">";
             }
@@ -204,7 +204,7 @@ namespace JECS.BuiltInBaseTypeLogics
 
                 var genericTypeBase = ParseTypeFromFullName(TypeFullName + "`" + GenericParameters.Count);
 
-                if (String.IsNullOrEmpty(GenericParameters[0].TypeFullName))
+                if (string.IsNullOrEmpty(GenericParameters[0].TypeFullName))
                     return genericTypeBase;
 
                 var genericParameterTypes = GenericParameters.Select(t => t.TurnIntoType()).ToArray();

--- a/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/Float types.cs
+++ b/JECS/Parsing Logic/Types/Base Types/Built-in base type logics/Float types.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Linq;
 

--- a/JECS/Parsing Logic/Types/Base Types/MultiLineStringSpecialCaseHandler.cs
+++ b/JECS/Parsing Logic/Types/Base Types/MultiLineStringSpecialCaseHandler.cs
@@ -1,4 +1,4 @@
-using JECS.BuiltInBaseTypeLogics;
+﻿using JECS.BuiltInBaseTypeLogics;
 using System;
 
 namespace JECS.ParsingLogic
@@ -29,7 +29,6 @@ namespace JECS.ParsingLogic
                 }
 
                 node.GetChildAddressedByStringLineNumber(lines.Length).MakeTerminator();
-                return;
             }
             else
             {
@@ -44,7 +43,7 @@ namespace JECS.ParsingLogic
 
             for (int i = 0; i < parentNode.ChildNodes.Count; i++)
             {
-                var lineNode = parentNode.ChildNodes[i] as MultiLineStringNode;
+                var lineNode = (MultiLineStringNode)parentNode.ChildNodes[i];
 
                 if (i == parentNode.ChildNodes.Count - 1)
                 {
@@ -66,7 +65,7 @@ namespace JECS.ParsingLogic
                 }
                 else
                 {
-                    text += (string)BaseStringRules.ParseItem(lineNode.Value);
+                    text += BaseStringRules.ParseItem(lineNode.Value);
 
                     if (!isLineBeforeTerminator)
                         text += Utilities.NewLine;

--- a/JECS/Parsing Logic/Types/Collection Types/Dictionaries.cs
+++ b/JECS/Parsing Logic/Types/Collection Types/Dictionaries.cs
@@ -41,7 +41,7 @@ namespace JECS.ParsingLogic.CollectionTypes
                 {
                     var value = dictionary[key];
 
-                    string keyAsText = BaseTypesManager.SerializeBaseType<TKey>(key, style);
+                    string keyAsText = BaseTypesManager.SerializeBaseType(key, style);
 
                     if (!Utilities.IsValidKey(keyAsText))
                     {
@@ -51,7 +51,7 @@ namespace JECS.ParsingLogic.CollectionTypes
 
                     CurrentKeys.Add(keyAsText);
                     KeyNode child = node.GetChildAddressedByName(keyAsText);
-                    NodeManager.SetNodeData<TValue>(child, value, style);
+                    NodeManager.SetNodeData(child, value, style);
                 }
 
                 // make sure that old data in the file is deleted when a new dictionary is saved.
@@ -93,7 +93,7 @@ namespace JECS.ParsingLogic.CollectionTypes
             {
                 foreach (var child in node.ChildNodes)
                 {
-                    string childKey = (child as KeyNode).Key;
+                    string childKey = ((KeyNode)child).Key;
                     var key = BaseTypesManager.ParseBaseType<TKey>(childKey);
                     var value = NodeManager.GetNodeData<TValue>(child);
                     dictionary.Add(key, value);
@@ -111,7 +111,7 @@ namespace JECS.ParsingLogic.CollectionTypes
 
         private static WritableKeyValuePair<TKey, TValue>[] GetWritableKeyValuePairArray<TKey, TValue>(Dictionary<TKey, TValue> boi)
         {
-            var unwritable = Enumerable.ToArray(boi);
+            var unwritable = boi.ToArray();
             var writable = new WritableKeyValuePair<TKey, TValue>[unwritable.Length];
 
             for (int i = 0; i < unwritable.Length; i++)

--- a/JECS/Parsing Logic/Types/Collection Types/HashSets.cs
+++ b/JECS/Parsing Logic/Types/Collection Types/HashSets.cs
@@ -31,7 +31,7 @@ namespace JECS.ParsingLogic.CollectionTypes
             int i = 0;
             foreach (var item in hashset)
             {
-                NodeManager.SetNodeData<T>(node.GetChildAddressedByListNumber(i), item, style);
+                NodeManager.SetNodeData(node.GetChildAddressedByListNumber(i), item, style);
                 i++;
             }
         }

--- a/JECS/Parsing Logic/Types/Collection Types/Lists.cs
+++ b/JECS/Parsing Logic/Types/Collection Types/Lists.cs
@@ -29,7 +29,7 @@ namespace JECS.ParsingLogic.CollectionTypes
             node.CapChildCount(list.Count);
 
             for (int i = 0; i < list.Count; i++)
-                NodeManager.SetNodeData<T>(node.GetChildAddressedByListNumber(i), list[i], style);
+                NodeManager.SetNodeData(node.GetChildAddressedByListNumber(i), list[i], style);
         }
 
         public static object RetrieveList(Node node, Type listType)

--- a/JECS/Parsing Logic/Types/Complex Types/ComplexTypeShortcuts.cs
+++ b/JECS/Parsing Logic/Types/Complex Types/ComplexTypeShortcuts.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 
 namespace JECS.ParsingLogic
@@ -8,10 +8,14 @@ namespace JECS.ParsingLogic
         internal static object GetFromShortcut(string shortcut, Type type)
         {
             object result;
-            if (TryPropertyShortcut(shortcut, type, out result)) return result;
-            if (TryConstructorShortcut(shortcut, type, out result)) return result;
-            if (TryMethodShortcut(shortcut, type, out result)) return result;
-            if (TryCustomShortCut(shortcut, type, out result)) return result;
+            if (TryPropertyShortcut(shortcut, type, out result))
+                return result;
+            if (TryConstructorShortcut(shortcut, type, out result))
+                return result;
+            if (TryMethodShortcut(shortcut, type, out result))
+                return result;
+            if (TryCustomShortCut(shortcut, type, out result))
+                return result;
 
             throw new FormatException($"{shortcut} is not a valid shortcut for type {type}");
         }
@@ -21,8 +25,10 @@ namespace JECS.ParsingLogic
             result = null;
             var p = type.GetProperty(name: shortcut, BindingFlags.Public | BindingFlags.Static);
 
-            if (p == null) return false;
-            if (p.CanWrite || p.PropertyType != type) return false;
+            if (p == null)
+                return false;
+            if (p.CanWrite || p.PropertyType != type)
+                return false;
 
             result = p.GetValue(null);
             return true;
@@ -31,46 +37,47 @@ namespace JECS.ParsingLogic
         private static bool TryConstructorShortcut(string shortcut, Type type, out object result)
         {
             try {
-            if (shortcut.StartsWith("(") && shortcut.EndsWith(")"))
-            {
-                string text = shortcut.Substring(1, shortcut.Length - 2); // remove the ( and )
-                var paramStrings = text.Split(',');
-
-                var constructors = type.GetConstructors();
-
-                ConstructorInfo constructor = constructors[0];
-
-                if (constructors.Length > 1)
+                if (shortcut.StartsWith("(") && shortcut.EndsWith(")"))
                 {
-                    foreach (var c in constructors)
+                    string text = shortcut.Substring(1, shortcut.Length - 2); // remove the ( and )
+                    var paramStrings = text.Split(',');
+
+                    var constructors = type.GetConstructors();
+
+                    ConstructorInfo constructor = constructors[0];
+
+                    if (constructors.Length > 1)
                     {
-                        // todo: it would be nice to check constructor parameter types for compatibility with paramStrings.
-                        // say a type had one constructor that took a string, and one constructor that took an int. We should be able to pick the right one.
-                        if (c.GetParameters().Length == paramStrings.Length)
+                        foreach (var c in constructors)
                         {
-                            constructor = c;
-                            break;
+                            // todo: it would be nice to check constructor parameter types for compatibility with paramStrings.
+                            // say a type had one constructor that took a string, and one constructor that took an int. We should be able to pick the right one.
+                            if (c.GetParameters().Length == paramStrings.Length)
+                            {
+                                constructor = c;
+                                break;
+                            }
                         }
                     }
-                }
 
-                var parameters = constructor.GetParameters();
-                var constructorParams = new object[parameters.Length];
-                for (int i = 0; i < parameters.Length; i++)
-                {
-                    if (i < paramStrings.Length)
+                    var parameters = constructor.GetParameters();
+                    var constructorParams = new object[parameters.Length];
+                    for (int i = 0; i < parameters.Length; i++)
                     {
-                        constructorParams[i] = BaseTypesManager.ParseBaseType(paramStrings[i].Trim(), parameters[i].ParameterType);
+                        if (i < paramStrings.Length)
+                        {
+                            constructorParams[i] = BaseTypesManager.ParseBaseType(paramStrings[i].Trim(), parameters[i].ParameterType);
+                        }
+                        else // optional parameter support
+                        {
+                            constructorParams[i] = parameters[i].DefaultValue;
+                        }
                     }
-                    else // optional parameter support
-                    {
-                        constructorParams[i] = parameters[i].DefaultValue;
-                    }
-                }
 
-                result = constructor.Invoke(constructorParams);
-                return true;
-            } } catch { } // I am a good programmer
+                    result = constructor.Invoke(constructorParams);
+                    return true;
+                }
+            } catch { } // I am a good programmer
 
             result = null;
             return false;
@@ -78,36 +85,37 @@ namespace JECS.ParsingLogic
 
         private static bool TryMethodShortcut(string shortcut, Type type, out object result)
         {
-            try { 
-            if (shortcut.Contains("(") && shortcut.Contains(")"))
-            {
-                string methodName = shortcut.Substring(0, shortcut.IndexOf('('));
-                var method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
-
-                if (method != null && method.ReturnType == type)
+            try {
+                if (shortcut.Contains("(") && shortcut.Contains(")"))
                 {
-                    var parameters = method.GetParameters();
+                    string methodName = shortcut.Substring(0, shortcut.IndexOf('('));
+                    var method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
 
-                    string s = shortcut.Substring(shortcut.IndexOf('(') + 1, shortcut.Length - shortcut.IndexOf('(') - 2);
-                    var paramStrings = s.Split(',');
-
-                    var methodParams = new object[parameters.Length];
-                    for (int i = 0; i < parameters.Length; i++)
+                    if (method != null && method.ReturnType == type)
                     {
-                        if (i < paramStrings.Length)
-                        {
-                            methodParams[i] = BaseTypesManager.ParseBaseType(paramStrings[i].Trim(), parameters[i].ParameterType);
-                        }
-                        else // optional parameter support
-                        {
-                            methodParams[i] = parameters[i].DefaultValue;
-                        }
-                    }
+                        var parameters = method.GetParameters();
 
-                    result = method.Invoke(null, methodParams);
-                    return true;
+                        string s = shortcut.Substring(shortcut.IndexOf('(') + 1, shortcut.Length - shortcut.IndexOf('(') - 2);
+                        var paramStrings = s.Split(',');
+
+                        var methodParams = new object[parameters.Length];
+                        for (int i = 0; i < parameters.Length; i++)
+                        {
+                            if (i < paramStrings.Length)
+                            {
+                                methodParams[i] = BaseTypesManager.ParseBaseType(paramStrings[i].Trim(), parameters[i].ParameterType);
+                            }
+                            else // optional parameter support
+                            {
+                                methodParams[i] = parameters[i].DefaultValue;
+                            }
+                        }
+
+                        result = method.Invoke(null, methodParams);
+                        return true;
+                    }
                 }
-            }} catch { } // Who am I kidding. I am a bad programmer :(
+            } catch { } // Who am I kidding. I am a bad programmer :(
 
             result = null;
             return false;
@@ -115,13 +123,16 @@ namespace JECS.ParsingLogic
 
         private static bool TryCustomShortCut(string shortcut, Type type, out object result)
         {
-            try { 
-            var m = type.GetMethod("Shortcut", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new Type[] { typeof(String) }, null);
-            if (m != null && m.ReturnType == type)
+            try
             {
-                result = m.Invoke(null, new object[] { shortcut });
-                return true;
-            }} catch { }
+                var m = type.GetMethod("Shortcut", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static, null, new Type[] { typeof(string) }, null);
+                if (m != null && m.ReturnType == type)
+                {
+                    result = m.Invoke(null, new object[] { shortcut });
+                    return true;
+                }
+            }
+            catch { }
 
             result = null;
             return false;

--- a/JECS/Parsing Logic/Types/Complex Types/ComplexTypes.cs
+++ b/JECS/Parsing Logic/Types/Complex Types/ComplexTypes.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace JECS.ParsingLogic
@@ -16,7 +15,7 @@ namespace JECS.ParsingLogic
             // Clear the shortcut if there is any
             if (node.HasValue)
                 node.ClearValue();
-            
+
 
             if (TypeRequiresSavingAsConcrete(type))
             {
@@ -26,7 +25,7 @@ namespace JECS.ParsingLogic
 
                 type = concreteType;
             }
-            
+
             foreach (var m in type.GetValidMembers())
             {
                 var child = node.GetChildAddressedByName(m.Name);
@@ -39,7 +38,7 @@ namespace JECS.ParsingLogic
             if (node.ChildNodes.Count > 0 && node.ChildNodeType != NodeChildrenType.Key)
                 throw new FormatException("Non-shortcut complex type nodes must have key children");
 
-            
+
             if (TypeRequiresSavingAsConcrete(type))
             {
                 var concreteTypeNode = node.GetChildAddressedByName(KEY_CONCRETE_TYPE);
@@ -47,12 +46,12 @@ namespace JECS.ParsingLogic
 
                 type = concreteType;
             }
-            
+
             object returnThis = Activator.CreateInstance(type);
 
             foreach (var m in type.GetValidMembers())
             {
-                if (!node.ContainsChildNode(m.Name)) 
+                if (!node.ContainsChildNode(m.Name))
                     continue;
 
                 var child = node.GetChildAddressedByName(m.Name);
@@ -69,20 +68,28 @@ namespace JECS.ParsingLogic
 
             foreach (var f in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
             {
-                if (f.IsInitOnly || f.IsLiteral) continue;
-                if (Attribute.IsDefined(f, typeof(DontSaveThisAttribute))) continue;
-                if (ComplexTypeOverrides.IsNeverSaved(f)) continue;
-                if (f.IsPrivate && !Attribute.IsDefined(f, typeof(SaveThisAttribute)) && !ComplexTypeOverrides.IsAlwaysSaved(f)) continue;
+                if (f.IsInitOnly || f.IsLiteral)
+                    continue;
+                if (Attribute.IsDefined(f, typeof(DontSaveThisAttribute)))
+                    continue;
+                if (ComplexTypeOverrides.IsNeverSaved(f))
+                    continue;
+                if (f.IsPrivate && !Attribute.IsDefined(f, typeof(SaveThisAttribute)) && !ComplexTypeOverrides.IsAlwaysSaved(f))
+                    continue;
 
                 members.Add(f);
             }
 
             foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
             {
-                if (!p.CanRead || !p.CanWrite || p.GetIndexParameters().Length > 0) continue;
-                if (Attribute.IsDefined(p, typeof(DontSaveThisAttribute))) continue;
-                if (ComplexTypeOverrides.IsNeverSaved(p)) continue;
-                if (p.GetMethod.IsPrivate && !Attribute.IsDefined(p, typeof(SaveThisAttribute)) && !ComplexTypeOverrides.IsAlwaysSaved(p)) continue;
+                if (!p.CanRead || !p.CanWrite || p.GetIndexParameters().Length > 0)
+                    continue;
+                if (Attribute.IsDefined(p, typeof(DontSaveThisAttribute)))
+                    continue;
+                if (ComplexTypeOverrides.IsNeverSaved(p))
+                    continue;
+                if (p.GetMethod.IsPrivate && !Attribute.IsDefined(p, typeof(SaveThisAttribute)) && !ComplexTypeOverrides.IsAlwaysSaved(p))
+                    continue;
 
                 members.Add(p);
             }

--- a/JECS/Utilities.cs
+++ b/JECS/Utilities.cs
@@ -1,7 +1,6 @@
 ﻿using JECS.ParsingLogic;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace JECS
 {
@@ -28,7 +27,7 @@ namespace JECS
 
         private static string GetDefaultDefaultPath()
         {
-            return System.AppContext.BaseDirectory;
+            return AppContext.BaseDirectory;
         }
 
         /// <summary> All JECS files have this file extension. </summary>
@@ -37,7 +36,7 @@ namespace JECS
         /// <summary> detects whether a file path is relative or absolute, and returns the absolute path </summary>
         public static string AbsolutePath(string relativeOrAbsolutePath)
         {
-            if (Path.IsPathRooted(relativeOrAbsolutePath)) 
+            if (Path.IsPathRooted(relativeOrAbsolutePath))
                 return relativeOrAbsolutePath;
 
             if (DefaultPath == null)
@@ -103,7 +102,7 @@ namespace JECS
             }
         }
 
-        internal static string NullIndicator { get; } = "null";
+        internal static string NullIndicator => "null";
     }
 
     /// <summary>


### PR DESCRIPTION
This PR is a combination of cleanup & API-extension & fixes. It also fixes some tests and adds new ones.
Basically a housekeeping PR, taking care of everything problematic encountered.

The core reason for this PR to be created was that `GetAsObject` was not as functional as it should. To fix it the API was extended. Which required new tests. And to keep sanity the code has been cleaned up first :P

For details on each change, please check the commits.
If there are any issue, I can fix anything requested.

JECS Fixes:
- Top-Level keys now must have indentation 0 (as the Wiki claimed).
- Multi-line strings now must be terminated by the end of the file.
- Blank lines with comments won't break multi-line strings anymore.
- JECS files with blank lines now consistently have a final newline.
- GetAsObject honors the default class field values again.

Also cleaned up the JECS text to nodes converter. I hope that code is more understandable now.