### PR TITLE
Fix WriteableReadableDataFile & GetAsObject()

### DIFF
--- a/JECS/DataFiles/Abstractions/ReadableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableDataFile.cs
@@ -158,12 +158,15 @@ namespace JECS.Abstractions
             return true;
         }
 
+        // many of these methods are virtual so that their overrides in ReadableWritableDataFile
+        // can have differing xml documentation.
+
         /// <summary> Like <see cref="Get{T}(string, T)"/>, but the default value is searched for in the default file text </summary>
-        public T Get<T>(string key)
+        public virtual T Get<T>(string key)
             => (T)GetNonGeneric(typeof(T), key);
 
         /// <summary> Like <see cref="GetNonGeneric(Type, string, object)"/>, but the default value is searched for in the default file text </summary>
-        public object GetNonGeneric(Type type, string key)
+        public virtual object GetNonGeneric(Type type, string key)
         {
             if (TryGetNonGeneric(type, key, out var dataValue))
                 return dataValue;
@@ -173,9 +176,6 @@ namespace JECS.Abstractions
 
             return type.GetDefaultValue();
         }
-
-        // many of these methods are virtual so that their overrides in ReadableWritableDataFile
-        // can have differing xml documentation.
 
         /// <summary> Get some data from the file, or return a default value if the data does not exist </summary>
         /// <param name="key"> what the data is labeled as within the file </param>
@@ -229,11 +229,11 @@ namespace JECS.Abstractions
         }
 
         /// <summary> Like <see cref="Get{T}(string)"/> but works for nested paths instead of just the top level of the file. </summary>
-        public T GetAtPath<T>(params string[] path)
+        public virtual T GetAtPath<T>(params string[] path)
             => (T)GetAtPathNonGeneric(typeof(T), path);
 
         /// <summary> Like <see cref="GetAtPathNonGeneric(Type, object, string[])"/>, but the value is searched for in the default file text </summary>
-        public object GetAtPathNonGeneric(Type type, params string[] path)
+        public virtual object GetAtPathNonGeneric(Type type, params string[] path)
         {
             if (TryGetAtPathNonGeneric(type, out var dataValue, path))
                 return dataValue;

--- a/JECS/DataFiles/Abstractions/ReadableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableDataFile.cs
@@ -23,7 +23,7 @@ namespace JECS.Abstractions
         /// <summary>
         /// When a default value is not supplied in Get, we search for it in this.
         /// </summary>
-        protected MemoryReadOnlyDataFile DefaultFileCache { get; }
+        internal MemoryReadOnlyDataFile DefaultFileCache { get; }
 
         public ReadableDataFile(string defaultFileText = null)
         {

--- a/JECS/DataFiles/Abstractions/ReadableWritableDataFile.cs
+++ b/JECS/DataFiles/Abstractions/ReadableWritableDataFile.cs
@@ -57,17 +57,40 @@ namespace JECS.Abstractions
                 SaveAllData();
         }
 
+        /// <summary> Get some data from the file, saving a new value if the data does not exist. </summary>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <typeparam name="T"> The type which the value is expected to be. </typeparam>
+        public override T Get<T>(string key)
+            => (T)GetNonGeneric(typeof(T), key);
 
-        /// <summary> Get some data from the file, saving a new value if the data does not exist </summary>
-        /// <param name="key"> what the data is labeled as within the file </param>
-        /// <param name="defaultValue"> if the key does not exist in the file, this value is saved there and returned </param>
+        /// <summary> Get some data from the file, saving a new value if the data does not exist. </summary>
+        /// <remarks> Non-generic version of <see cref="Get{T}(string)"/>. You probably want to use <see cref="Get{T}(string)"/>. </remarks>
+        /// <param name="type"> The type which the value is expected to be. </param>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        public override object GetNonGeneric(Type type, string key)
+        {
+            if (TryGetNonGeneric(type, key, out var value))
+                return value;
+
+            if (DefaultFileCache == null || !DefaultFileCache.TryGetNonGeneric(type, key, out var defaultValue))
+                defaultValue = type.GetDefaultValue();
+
+            SetNonGeneric(type, key, defaultValue);
+            return defaultValue;
+        }
+
+        /// <summary> Get some data from the file, saving a new value if the data does not exist. </summary>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <param name="defaultValue"> If the <paramref name="key"/> does not exist in the file, this value is saved there and returned. </param>
+        /// <typeparam name="T"> The type which the value is expected to be. </typeparam>
         public override T Get<T>(string key, T defaultValue)
-            => base.Get(key, defaultValue);
+            => (T)GetNonGeneric(typeof(T), key, defaultValue);
 
-        /// <summary> Non-generic version of Get. You probably want to use Get. </summary>
-        /// <param name="type"> the type to get the data as </param>
-        /// <param name="key"> what the data is labeled as within the file </param>
-        /// <param name="defaultValue"> if the key does not exist in the file, this value is saved there and returned </param>
+        /// <summary> Get some data from the file, saving a new value if the data does not exist. </summary>
+        /// <remarks> Non-generic version of <see cref="Get{T}(string,T)"/>. You probably want to use <see cref="Get{T}(string,T)"/>. </remarks>
+        /// <param name="type"> The type which the value is expected to be. </param>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <param name="defaultValue"> If the <paramref name="key"/> does not exist in the file, this value is saved there and returned. </param>
         public override object GetNonGeneric(Type type, string key, object defaultValue)
         {
             if (TryGetNonGeneric(type, key, out var value))
@@ -77,16 +100,18 @@ namespace JECS.Abstractions
             return defaultValue;
         }
 
-        /// <summary> Save data to the file </summary>
-        /// <param name="key"> what the data is labeled as within the file </param>
-        /// <param name="value"> the value to save </param>
+        /// <summary> Save data to the file. </summary>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <param name="value"> The value to save. </param>
+        /// <typeparam name="T"> The type to save the data as. </typeparam>
         public void Set<T>(string key, T value)
             => SetNonGeneric(typeof(T), key, value);
 
-        /// <summary> Non-generic version of Set. You probably want to use Set. </summary>
-        /// <param name="type"> the type to save the data as </param>
-        /// <param name="key"> what the data is labeled as within the file </param>
-        /// <param name="value"> the value to save </param>
+        /// <summary> Save data to the file. </summary>
+        /// <remarks> Non-generic version of <see cref="Set{T}"/>. You probably want to use <see cref="Set{T}"/>. </remarks>
+        /// <param name="type"> The type to save the data as. </param>
+        /// <param name="key"> What the data is labeled as within the file. </param>
+        /// <param name="value"> The value to save. </param>
         public void SetNonGeneric(Type type, string key, object value)
         {
             EnsureValueIsCorrectType(type, value);
@@ -105,7 +130,30 @@ namespace JECS.Abstractions
         }
 
 
-        /// <inheritdoc/>
+        /// <summary> Like <see cref="Get{T}(string)"/> but works for nested paths instead of just the top level of the file. </summary>
+        public override T GetAtPath<T>(params string[] path)
+            => (T)GetAtPathNonGeneric(typeof(T), path);
+
+        /// <summary> Like <see cref="GetNonGeneric(System.Type,string)"/> but works for nested paths instead of just the top level of the file. </summary>
+        /// <remarks> Non-generic version of <see cref="GetAtPath{T}(string[])"/>. You probably want to use <see cref="GetAtPath{T}(string[])"/>. </remarks>
+        public override object GetAtPathNonGeneric(Type type, params string[] path)
+        {
+            if (TryGetAtPathNonGeneric(type, out var value, path))
+                return value;
+
+            if (DefaultFileCache == null || !DefaultFileCache.TryGetAtPathNonGeneric(type, out var defaultValue, path))
+                defaultValue = type.GetDefaultValue();
+
+            SetAtPathNonGeneric(type, defaultValue, path);
+            return defaultValue;
+        }
+
+        /// <summary> Like <see cref="Get{T}(string,T)"/> but works for nested paths instead of just the top level of the file. </summary>
+        public override T GetAtPath<T>(T defaultValue, params string[] path)
+            => (T)GetAtPathNonGeneric(typeof(T), defaultValue, path);
+
+        /// <summary> Like <see cref="GetNonGeneric(System.Type,string,object)"/> but works for nested paths instead of just the top level of the file. </summary>
+        /// <remarks> Non-generic version of <see cref="GetAtPath{T}(T,string[])"/>. You probably want to use <see cref="GetAtPath{T}(T,string[])"/>. </remarks>
         public override object GetAtPathNonGeneric(Type type, object defaultValue, params string[] path)
         {
             if (TryGetAtPathNonGeneric(type, out var value, path))
@@ -119,7 +167,8 @@ namespace JECS.Abstractions
         public void SetAtPath<T>(T value, params string[] path)
             => SetAtPathNonGeneric(typeof(T), value, path);
 
-        /// <summary> Non-generic version of SetAtPath. You probably want to use SetAtPath. </summary>
+        /// <summary> Like <see cref="SetNonGeneric"/> but works for nested paths instead of just the top level of the file. </summary>
+        /// <summary> Non-generic version of <see cref="SetAtPath{T}"/>. You probably want to use <see cref="SetAtPath{T}"/>. </summary>
         public void SetAtPathNonGeneric(Type type, object value, params string[] path)
         {
             EnsureValueIsCorrectType(type, value);

--- a/JECS/DataFiles/DataFileExtensions.cs
+++ b/JECS/DataFiles/DataFileExtensions.cs
@@ -44,7 +44,8 @@ namespace JECS
             foreach (var m in type.GetValidMembers())
             {
                 // Only overwrite the instantiated default field, when there is a value. This preserves default class assignments.
-                if (dataFile.TryGetNonGeneric(m.MemberType, m.Name, out var value))
+                if (dataFile.TryGetNonGeneric(m.MemberType, m.Name, out var value)
+                    || (dataFile.DefaultFileCache?.TryGetNonGeneric(m.MemberType, m.Name, out value) ?? false))
                     m.SetValue(returnThis, value);
             }
 


### PR DESCRIPTION
I am afraid in my last PR, I mistakenly broke a feature of `WriteableReadableDataFile`.
The code heavily relied on the parent class `ReadableDataFile` forwarding all getter method calls to two specific get methods, which had been overloaded in the child class. With my cleanup, these overloads got changed to behave different.
Now the Writable class was no longer able to set unset values in the files while executing get methods.
This has been corrected in this PR.

Also fixed `GetAsObject()` not behaving as the API methods should behave (as in falling back to provided JECS default text, when no value is found).